### PR TITLE
Add chat interface and OneDrive integration

### DIFF
--- a/InsightMate/.gitignore
+++ b/InsightMate/.gitignore
@@ -1,0 +1,11 @@
+# macOS
+.DS_Store
+build/
+DerivedData/
+
+# Python
+__pycache__/
+*.pyc
+
+# OAuth tokens
+Scripts/token.json

--- a/InsightMate/InsightMateApp/.gitignore
+++ b/InsightMate/InsightMateApp/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/InsightMate/InsightMateApp/InsightMateApp.xcodeproj/project.pbxproj
+++ b/InsightMate/InsightMateApp/InsightMateApp.xcodeproj/project.pbxproj
@@ -1,0 +1,174 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  classes = {};
+  objectVersion = 52;
+  objects = {
+
+    1D6058900D05DD3D006BFB54 /* Project object */ = {
+      isa = PBXProject;
+      buildConfigurationList = 1D6058910D05DD3E006BFB54 /* Build configuration list */;
+      compatibilityVersion = "Xcode 12.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = C26F24321F4A5E3500169F2D /* Main Group */;
+      productRefGroup = C26F24321F4A5E3500169F2D /* Main Group */;
+      projectDirPath = "";
+      projectRoot = "";
+      targets = (
+        C26F24341F4A5E3500169F2D /* InsightMateApp */,
+      );
+    };
+
+    C26F24321F4A5E3500169F2D /* Main Group */ = {
+      isa = PBXGroup;
+      children = (
+        C26F24351F4A5E3500169F2D /* Sources */, 
+        C26F24381F4A5E3500169F2D /* Resources */, 
+        C26F24361F4A5E3500169F2D /* Products */, 
+      );
+      sourceTree = "<group>";
+    };
+
+    C26F24351F4A5E3500169F2D /* Sources */ = {
+      isa = PBXGroup;
+      children = (
+        C26F243B1F4A5E3500169F2D /* InsightMateApp.swift */,
+      );
+      path = Sources;
+      sourceTree = "<group>";
+    };
+
+    C26F24381F4A5E3500169F2D /* Resources */ = {
+      isa = PBXGroup;
+      children = (
+        C26F243C1F4A5E3500169F2D /* Assets.xcassets */,
+        C26F243D1F4A5E3500169F2D /* py */,
+      );
+      path = Resources;
+      sourceTree = "<group>";
+    };
+
+    C26F24361F4A5E3500169F2D /* Products */ = {
+      isa = PBXGroup;
+      children = (
+        C26F24341F4A5E3500169F2E /* InsightMateApp.app */,
+      );
+      name = Products;
+      sourceTree = "<group>";
+    };
+
+    C26F24341F4A5E3500169F2D /* InsightMateApp */ = {
+      isa = PBXNativeTarget;
+      buildConfigurationList = C26F24451F4A5E4B00169F2D /* Build configuration list for PBXNativeTarget \"InsightMateApp\" */;
+      buildPhases = (
+        C26F24401F4A5E4000169F2D /* Sources */, 
+        C26F24411F4A5E4000169F2D /* Resources */,
+      );
+      buildRules = (
+      );
+      dependencies = (
+      );
+      name = InsightMateApp;
+      productName = InsightMateApp;
+      productReference = C26F24341F4A5E3500169F2E /* InsightMateApp.app */;
+      productType = "com.apple.product-type.application";
+    };
+
+    C26F24401F4A5E4000169F2D /* Sources */ = {
+      isa = PBXSourcesBuildPhase;
+      buildActionMask = 2147483647;
+      files = (
+        C26F24421F4A5E4300169F2D /* InsightMateApp.swift in Sources */,
+      );
+      runOnlyForDeploymentPostprocessing = 0;
+    };
+
+    C26F24411F4A5E4000169F2D /* Resources */ = {
+      isa = PBXResourcesBuildPhase;
+      buildActionMask = 2147483647;
+      files = (
+        C26F24431F4A5E4300169F2D /* Assets.xcassets in Resources */,
+        C26F24441F4A5E4300169F2D /* py in Resources */,
+      );
+      runOnlyForDeploymentPostprocessing = 0;
+    };
+
+    C26F243B1F4A5E3500169F2D /* InsightMateApp.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightMateApp.swift; sourceTree = "<group>"; };
+    C26F243C1F4A5E3500169F2D /* Assets.xcassets */ = { isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+    C26F243D1F4A5E3500169F2D /* py */ = { isa = PBXFileReference; lastKnownFileType = folder; path = py; sourceTree = "<group>"; };
+    C26F24341F4A5E3500169F2E /* InsightMateApp.app */ = { isa = PBXFileReference; explicitFileType = wrapper.application; path = InsightMateApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+
+    /* Build configuration list for PBXProject "InsightMateApp" */
+    1D6058910D05DD3E006BFB54 = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        C26F24461F4A5E4B00169F2D /* Debug */,
+        C26F24471F4A5E4B00169F2D /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+
+    /* Build configuration list for PBXNativeTarget "InsightMateApp" */
+    C26F24451F4A5E4B00169F2D = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        C26F24481F4A5E4B00169F2D /* Debug */,
+        C26F24491F4A5E4B00169F2D /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+
+    C26F24461F4A5E4B00169F2D /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+        PRODUCT_NAME = "InsightMateApp";
+        SWIFT_VERSION = 5.0;
+        MACOSX_DEPLOYMENT_TARGET = 11.0;
+      };
+      name = Debug;
+    };
+    C26F24471F4A5E4B00169F2D /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+        PRODUCT_NAME = "InsightMateApp";
+        SWIFT_VERSION = 5.0;
+        MACOSX_DEPLOYMENT_TARGET = 11.0;
+      };
+      name = Release;
+    };
+
+    C26F24481F4A5E4B00169F2D /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+        INFOPLIST_FILE = Resources/Info.plist;
+        PRODUCT_BUNDLE_IDENTIFIER = com.example.InsightMate;
+        PRODUCT_NAME = "InsightMate";
+        SWIFT_VERSION = 5.0;
+        CODE_SIGN_STYLE = Automatic;
+        ENABLE_HARDENED_RUNTIME = YES;
+        SYSTEM_EXTENSIONS_FOLDER = "$(PROJECT_DIR)";
+        ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon";
+      };
+      name = Debug;
+    };
+    C26F24491F4A5E4B00169F2D /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+        INFOPLIST_FILE = Resources/Info.plist;
+        PRODUCT_BUNDLE_IDENTIFIER = com.example.InsightMate;
+        PRODUCT_NAME = "InsightMate";
+        SWIFT_VERSION = 5.0;
+        CODE_SIGN_STYLE = Automatic;
+        ENABLE_HARDENED_RUNTIME = YES;
+        SYSTEM_EXTENSIONS_FOLDER = "$(PROJECT_DIR)";
+        ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon";
+      };
+      name = Release;
+    };
+
+  };
+  rootObject = 1D6058900D05DD3D006BFB54 /* Project object */;
+}

--- a/InsightMate/InsightMateApp/Package.swift
+++ b/InsightMate/InsightMateApp/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "InsightMateApp",
+    platforms: [
+        .macOS(.v11)
+    ],
+    targets: [
+        .executableTarget(
+            name: "InsightMateApp",
+            resources: [
+                .copy("Resources/py"),
+                .process("Resources/Assets.xcassets")
+            ]
+        )
+    ]
+)

--- a/InsightMate/InsightMateApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/InsightMate/InsightMateApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "images" : [
+    {
+      "filename" : "",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/InsightMate/InsightMateApp/Resources/Info.plist
+++ b/InsightMate/InsightMateApp/Resources/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.InsightMate</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/InsightMate/InsightMateApp/Resources/py/ai_server.py
+++ b/InsightMate/InsightMateApp/Resources/py/ai_server.py
@@ -1,0 +1,34 @@
+import os
+from flask import Flask, request, jsonify
+import openai
+
+app = Flask(__name__)
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+@app.route('/process', methods=['POST'])
+def process():
+    data = request.get_json() or {}
+    imessage = data.get('imessage')
+    email = data.get('email')
+    calendar = data.get('calendar')
+    onedrive = data.get('onedrive')
+    user_prompt = data.get('prompt', '')
+    prompt = (
+        "You are an assistant helping the user with their data.\n"
+        f"Latest iMessage: {imessage}\n"
+        f"Unread email: {email}\n"
+        f"Today's calendar events: {calendar}\n"
+        f"Recent OneDrive files: {onedrive}\n"
+        f"User question: {user_prompt}\n"
+        "Answer appropriately."
+    )
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    reply = response['choices'][0]['message']['content'].strip()
+    return jsonify({'reply': reply})
+
+if __name__ == '__main__':
+    app.run(port=5000)

--- a/InsightMate/InsightMateApp/Resources/py/calendar_reader.py
+++ b/InsightMate/InsightMateApp/Resources/py/calendar_reader.py
@@ -1,0 +1,50 @@
+import datetime
+import os
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+TOKEN_FILE = 'token.json'
+CREDENTIALS_FILE = 'credentials.json'
+
+
+def get_credentials():
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+    return creds
+
+
+def list_today_events():
+    creds = get_credentials()
+    service = build('calendar', 'v3', credentials=creds)
+    start = datetime.datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + datetime.timedelta(days=1)
+    events_result = service.events().list(
+        calendarId='primary',
+        timeMin=start.isoformat() + 'Z',
+        timeMax=end.isoformat() + 'Z',
+        singleEvents=True,
+        orderBy='startTime'
+    ).execute()
+    events = events_result.get('items', [])
+    output = []
+    for e in events:
+        start_time = e['start'].get('dateTime', e['start'].get('date'))
+        end_time = e['end'].get('dateTime', e['end'].get('date'))
+        output.append({'title': e.get('summary', ''), 'start': start_time, 'end': end_time})
+    return output
+
+
+if __name__ == '__main__':
+    print(list_today_events())

--- a/InsightMate/InsightMateApp/Resources/py/gmail_reader.py
+++ b/InsightMate/InsightMateApp/Resources/py/gmail_reader.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+import os.path
+from email.header import decode_header, make_header
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+
+SCOPES = ['https://www.googleapis.com/auth/gmail.readonly',
+          'https://www.googleapis.com/auth/calendar.readonly']
+
+TOKEN_FILE = 'token.json'
+CREDENTIALS_FILE = 'credentials.json'
+
+
+def get_credentials():
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+    return creds
+
+
+def fetch_unread_email():
+    creds = get_credentials()
+    service = build('gmail', 'v1', credentials=creds)
+    results = service.users().messages().list(userId='me', labelIds=['INBOX'], q='is:unread').execute()
+    messages = results.get('messages', [])
+    if not messages:
+        return None
+    msg = service.users().messages().get(userId='me', id=messages[0]['id'], format='full').execute()
+    headers = {h['name']: str(make_header(decode_header(h['value']))) for h in msg['payload']['headers']}
+    sender = headers.get('From', '')
+    subject = headers.get('Subject', '')
+    snippet = msg.get('snippet', '')[:250]
+    return {'from': sender, 'subject': subject, 'snippet': snippet}
+
+
+if __name__ == '__main__':
+    print(fetch_unread_email())

--- a/InsightMate/InsightMateApp/Resources/py/imessage_reader.py
+++ b/InsightMate/InsightMateApp/Resources/py/imessage_reader.py
@@ -1,0 +1,26 @@
+import os
+import sqlite3
+from datetime import datetime
+
+CHAT_DB = os.path.expanduser('~/Library/Messages/chat.db')
+
+
+def read_latest_imessage():
+    conn = sqlite3.connect(CHAT_DB)
+    c = conn.cursor()
+    query = (
+        "SELECT handle.id, message.text, message.date \
+         FROM message JOIN handle ON message.handle_id = handle.ROWID \
+         WHERE message.is_from_me = 0 \
+         ORDER BY message.date DESC LIMIT 1"
+    )
+    row = c.execute(query).fetchone()
+    conn.close()
+    if not row:
+        return None
+    sender, text, date = row
+    return {"from": sender, "message": text or ""}
+
+
+if __name__ == '__main__':
+    print(read_latest_imessage())

--- a/InsightMate/InsightMateApp/Resources/py/main.py
+++ b/InsightMate/InsightMateApp/Resources/py/main.py
@@ -1,0 +1,43 @@
+import json
+import os
+import requests
+
+from imessage_reader import read_latest_imessage
+from gmail_reader import fetch_unread_email
+from calendar_reader import list_today_events
+from onedrive_reader import list_recent_files
+from send_imessage import send_imessage
+
+SERVER_URL = 'http://localhost:5000/process'
+OUTPUT_FILE = '/tmp/insight_output.txt'
+
+def main(prompt: str = "Summarize recent activity."):
+    print('Reading data...')
+    imsg = read_latest_imessage()
+    email = fetch_unread_email()
+    cal = list_today_events()
+    drive = list_recent_files()
+    payload = {
+        'imessage': imsg,
+        'email': email,
+        'calendar': cal,
+        'onedrive': drive,
+        'prompt': prompt,
+    }
+    print('Sending to AI server...')
+    resp = requests.post(SERVER_URL, json=payload)
+    reply = resp.json().get('reply', '')
+    print('AI reply:', reply)
+    with open(OUTPUT_FILE, 'w') as f:
+        f.write(reply)
+    if imsg:
+        try:
+            send_imessage(imsg['from'], reply)
+        except Exception as e:
+            print('Failed to send iMessage:', e)
+
+
+if __name__ == '__main__':
+    import sys
+    user_prompt = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "Summarize recent activity."
+    main(user_prompt)

--- a/InsightMate/InsightMateApp/Resources/py/onedrive_reader.py
+++ b/InsightMate/InsightMateApp/Resources/py/onedrive_reader.py
@@ -1,0 +1,44 @@
+import os
+import json
+import requests
+import msal
+
+CLIENT_ID = os.getenv('MS_CLIENT_ID')
+TENANT_ID = os.getenv('MS_TENANT_ID', 'common')
+SCOPES = ['Files.Read']
+TOKEN_FILE = 'ms_token.json'
+
+token_cache = msal.SerializableTokenCache()
+if os.path.exists(TOKEN_FILE):
+    token_cache.deserialize(open(TOKEN_FILE).read())
+
+app = msal.PublicClientApplication(
+    CLIENT_ID,
+    authority=f"https://login.microsoftonline.com/{TENANT_ID}",
+    token_cache=token_cache
+)
+
+def get_token():
+    accounts = app.get_accounts()
+    if accounts:
+        result = app.acquire_token_silent(SCOPES, account=accounts[0])
+    else:
+        flow = app.initiate_device_flow(scopes=SCOPES)
+        print(flow['message'])
+        result = app.acquire_token_by_device_flow(flow)
+    if 'access_token' in result:
+        with open(TOKEN_FILE, 'w') as f:
+            f.write(token_cache.serialize())
+        return result['access_token']
+    raise RuntimeError('Failed to acquire token')
+
+def list_recent_files(limit=5):
+    token = get_token()
+    headers = {'Authorization': f'Bearer {token}'}
+    url = 'https://graph.microsoft.com/v1.0/me/drive/recent'
+    resp = requests.get(url, headers=headers)
+    items = resp.json().get('value', [])[:limit]
+    return [{'name': i.get('name'), 'id': i.get('id')} for i in items]
+
+if __name__ == '__main__':
+    print(list_recent_files())

--- a/InsightMate/InsightMateApp/Resources/py/requirements.txt
+++ b/InsightMate/InsightMateApp/Resources/py/requirements.txt
@@ -1,0 +1,7 @@
+flask
+openai
+google-auth
+google-auth-oauthlib
+google-api-python-client
+requests
+msal

--- a/InsightMate/InsightMateApp/Resources/py/send_imessage.py
+++ b/InsightMate/InsightMateApp/Resources/py/send_imessage.py
@@ -1,0 +1,14 @@
+import subprocess
+
+
+def send_imessage(to: str, body: str):
+    script = f'''tell application "Messages"
+        send "{body}" to buddy "{to}" of (service 1 whose service type is iMessage)
+    end tell'''
+    subprocess.run(['osascript', '-e', script], check=True)
+
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) >= 3:
+        send_imessage(sys.argv[1], ' '.join(sys.argv[2:]))

--- a/InsightMate/InsightMateApp/Sources/InsightMateApp.swift
+++ b/InsightMate/InsightMateApp/Sources/InsightMateApp.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import AppKit
+
+@main
+struct InsightMateApp: App {
+    @State private var isRunning = false
+    @State private var chatWindow: NSWindow?
+
+    var body: some Scene {
+        MenuBarExtra("InsightMate", systemImage: "brain") {
+            Button("Run Assistant") { runAssistant() }
+            Button("Chat…") { openChat() }
+            Button("Preferences…") {}
+            Divider()
+            Button("Quit") {
+                NSApplication.shared.terminate(nil)
+            }
+        }
+    }
+
+    func startServerIfNeeded() {
+        let check = Process()
+        check.launchPath = "/usr/bin/pgrep"
+        check.arguments = ["-f", "ai_server.py"]
+        check.standardOutput = Pipe()
+        try? check.run()
+        check.waitUntilExit()
+        if check.terminationStatus != 0 {
+            let resourceURL = Bundle.main.resourceURL!.appendingPathComponent("py")
+            let server = resourceURL.appendingPathComponent("ai_server.py").path
+            let proc = Process()
+            proc.launchPath = "/usr/bin/python3"
+            proc.arguments = ["-u", server]
+            proc.standardOutput = nil
+            proc.standardError = nil
+            try? proc.run()
+        }
+    }
+
+    func runAssistant(prompt: String? = nil, completion: ((String) -> Void)? = nil) {
+        guard !isRunning else { return }
+        isRunning = true
+        startServerIfNeeded()
+        let resourceURL = Bundle.main.resourceURL!.appendingPathComponent("py")
+        let script = resourceURL.appendingPathComponent("main.py").path
+        let process = Process()
+        process.launchPath = "/usr/bin/python3"
+        var args = ["-u", script]
+        if let p = prompt { args.append(p) }
+        process.arguments = args
+        process.terminationHandler = { _ in
+            isRunning = false
+            let outputPath = "/tmp/insight_output.txt"
+            let body = (try? String(contentsOfFile: outputPath)) ?? ""
+            if let completion = completion {
+                completion(body)
+            } else {
+                notifyCompletion(body: body)
+            }
+        }
+        try? process.run()
+    }
+
+    func notifyCompletion(body: String) {
+        let notification = NSUserNotification()
+        notification.title = "InsightMate"
+        notification.informativeText = body
+        NSUserNotificationCenter.default.deliver(notification)
+    }
+
+    func openChat() {
+        if chatWindow == nil {
+            let chatView = ChatView { prompt, cb in
+                runAssistant(prompt: prompt, completion: cb)
+            }
+            chatWindow = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 320, height: 400),
+                styleMask: [.titled, .closable, .resizable],
+                backing: .buffered,
+                defer: false
+            )
+            chatWindow?.title = "InsightMate Chat"
+            chatWindow?.contentView = NSHostingView(rootView: chatView)
+        }
+        chatWindow?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+struct ChatView: View {
+    var run: (String, @escaping (String) -> Void) -> Void
+    @State private var input = ""
+    @State private var transcript = ""
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                Text(transcript)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            HStack {
+                TextField("Message", text: $input)
+                Button("Send") {
+                    let prompt = input
+                    input = ""
+                    run(prompt) { reply in
+                        DispatchQueue.main.async {
+                            transcript += "\nYou: \(prompt)\nAI: \(reply)"
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}

--- a/InsightMate/InsightMateApp/Sources/old_main.swift
+++ b/InsightMate/InsightMateApp/Sources/old_main.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+print("Hello, world!")

--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -1,0 +1,45 @@
+# InsightMate
+
+InsightMate is a macOS menu bar assistant that summarizes your recent iMessage, Gmail, Calendar and OneDrive activity using a local Python backend and GPT‑4. It also provides a small chat window for interactive questions.
+
+## Project Layout
+
+- `InsightMateApp/` – SwiftUI menu bar application
+- `Scripts/` – same Python sources for running outside the app
+
+The Xcode target embeds the Python files from `InsightMateApp/Resources/py/` so they
+run using the system `/usr/bin/python3`.
+
+## Prerequisites
+
+- macOS with Xcode 14 or later
+- Python 3 (already available at `/usr/bin/python3` on macOS)
+- An OpenAI API key exported as `OPENAI_API_KEY`
+- Google OAuth `credentials.json` placed inside the `Scripts/` folder (used for Gmail and Calendar)
+- Full Disk Access for Terminal or the built app so iMessage can be read
+
+## Build & Run
+
+1. Open `InsightMateApp/InsightMateApp.xcodeproj` in Xcode.
+2. Build and run the `InsightMateApp` target.
+   - On first launch the app starts `ai_server.py` in the background if it's not running.
+   - It then executes `main.py` which collects iMessage, Gmail, Calendar and OneDrive data and posts it to the local server.
+3. After the Python script finishes, a notification appears with the response
+   (also written to `/tmp/insight_output.txt`).
+
+## Running the Backend Manually
+
+You can run the Python components without the SwiftUI app:
+
+```bash
+cd InsightMate/Scripts
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...
+python ai_server.py &
+python main.py "What's new?"
+```
+
+The Flask server listens on `http://localhost:5000` and `main.py` writes the assistant reply to `/tmp/insight_output.txt`.
+

--- a/InsightMate/Scripts/ai_server.py
+++ b/InsightMate/Scripts/ai_server.py
@@ -1,0 +1,34 @@
+import os
+from flask import Flask, request, jsonify
+import openai
+
+app = Flask(__name__)
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+@app.route('/process', methods=['POST'])
+def process():
+    data = request.get_json() or {}
+    imessage = data.get('imessage')
+    email = data.get('email')
+    calendar = data.get('calendar')
+    onedrive = data.get('onedrive')
+    user_prompt = data.get('prompt', '')
+    prompt = (
+        "You are an assistant helping the user with their data.\n"
+        f"Latest iMessage: {imessage}\n"
+        f"Unread email: {email}\n"
+        f"Today's calendar events: {calendar}\n"
+        f"Recent OneDrive files: {onedrive}\n"
+        f"User question: {user_prompt}\n"
+        "Answer appropriately."
+    )
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    reply = response['choices'][0]['message']['content'].strip()
+    return jsonify({'reply': reply})
+
+if __name__ == '__main__':
+    app.run(port=5000)

--- a/InsightMate/Scripts/calendar_reader.py
+++ b/InsightMate/Scripts/calendar_reader.py
@@ -1,0 +1,50 @@
+import datetime
+import os
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+TOKEN_FILE = 'token.json'
+CREDENTIALS_FILE = 'credentials.json'
+
+
+def get_credentials():
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+    return creds
+
+
+def list_today_events():
+    creds = get_credentials()
+    service = build('calendar', 'v3', credentials=creds)
+    start = datetime.datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + datetime.timedelta(days=1)
+    events_result = service.events().list(
+        calendarId='primary',
+        timeMin=start.isoformat() + 'Z',
+        timeMax=end.isoformat() + 'Z',
+        singleEvents=True,
+        orderBy='startTime'
+    ).execute()
+    events = events_result.get('items', [])
+    output = []
+    for e in events:
+        start_time = e['start'].get('dateTime', e['start'].get('date'))
+        end_time = e['end'].get('dateTime', e['end'].get('date'))
+        output.append({'title': e.get('summary', ''), 'start': start_time, 'end': end_time})
+    return output
+
+
+if __name__ == '__main__':
+    print(list_today_events())

--- a/InsightMate/Scripts/gmail_reader.py
+++ b/InsightMate/Scripts/gmail_reader.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+import os.path
+from email.header import decode_header, make_header
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+
+SCOPES = ['https://www.googleapis.com/auth/gmail.readonly',
+          'https://www.googleapis.com/auth/calendar.readonly']
+
+TOKEN_FILE = 'token.json'
+CREDENTIALS_FILE = 'credentials.json'
+
+
+def get_credentials():
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+    return creds
+
+
+def fetch_unread_email():
+    creds = get_credentials()
+    service = build('gmail', 'v1', credentials=creds)
+    results = service.users().messages().list(userId='me', labelIds=['INBOX'], q='is:unread').execute()
+    messages = results.get('messages', [])
+    if not messages:
+        return None
+    msg = service.users().messages().get(userId='me', id=messages[0]['id'], format='full').execute()
+    headers = {h['name']: str(make_header(decode_header(h['value']))) for h in msg['payload']['headers']}
+    sender = headers.get('From', '')
+    subject = headers.get('Subject', '')
+    snippet = msg.get('snippet', '')[:250]
+    return {'from': sender, 'subject': subject, 'snippet': snippet}
+
+
+if __name__ == '__main__':
+    print(fetch_unread_email())

--- a/InsightMate/Scripts/imessage_reader.py
+++ b/InsightMate/Scripts/imessage_reader.py
@@ -1,0 +1,26 @@
+import os
+import sqlite3
+from datetime import datetime
+
+CHAT_DB = os.path.expanduser('~/Library/Messages/chat.db')
+
+
+def read_latest_imessage():
+    conn = sqlite3.connect(CHAT_DB)
+    c = conn.cursor()
+    query = (
+        "SELECT handle.id, message.text, message.date \
+         FROM message JOIN handle ON message.handle_id = handle.ROWID \
+         WHERE message.is_from_me = 0 \
+         ORDER BY message.date DESC LIMIT 1"
+    )
+    row = c.execute(query).fetchone()
+    conn.close()
+    if not row:
+        return None
+    sender, text, date = row
+    return {"from": sender, "message": text or ""}
+
+
+if __name__ == '__main__':
+    print(read_latest_imessage())

--- a/InsightMate/Scripts/main.py
+++ b/InsightMate/Scripts/main.py
@@ -1,0 +1,43 @@
+import json
+import os
+import requests
+
+from imessage_reader import read_latest_imessage
+from gmail_reader import fetch_unread_email
+from calendar_reader import list_today_events
+from onedrive_reader import list_recent_files
+from send_imessage import send_imessage
+
+SERVER_URL = 'http://localhost:5000/process'
+OUTPUT_FILE = '/tmp/insight_output.txt'
+
+def main(prompt: str = "Summarize recent activity."):
+    print('Reading data...')
+    imsg = read_latest_imessage()
+    email = fetch_unread_email()
+    cal = list_today_events()
+    drive = list_recent_files()
+    payload = {
+        'imessage': imsg,
+        'email': email,
+        'calendar': cal,
+        'onedrive': drive,
+        'prompt': prompt,
+    }
+    print('Sending to AI server...')
+    resp = requests.post(SERVER_URL, json=payload)
+    reply = resp.json().get('reply', '')
+    print('AI reply:', reply)
+    with open(OUTPUT_FILE, 'w') as f:
+        f.write(reply)
+    if imsg:
+        try:
+            send_imessage(imsg['from'], reply)
+        except Exception as e:
+            print('Failed to send iMessage:', e)
+
+
+if __name__ == '__main__':
+    import sys
+    user_prompt = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "Summarize recent activity."
+    main(user_prompt)

--- a/InsightMate/Scripts/onedrive_reader.py
+++ b/InsightMate/Scripts/onedrive_reader.py
@@ -1,0 +1,44 @@
+import os
+import json
+import requests
+import msal
+
+CLIENT_ID = os.getenv('MS_CLIENT_ID')
+TENANT_ID = os.getenv('MS_TENANT_ID', 'common')
+SCOPES = ['Files.Read']
+TOKEN_FILE = 'ms_token.json'
+
+token_cache = msal.SerializableTokenCache()
+if os.path.exists(TOKEN_FILE):
+    token_cache.deserialize(open(TOKEN_FILE).read())
+
+app = msal.PublicClientApplication(
+    CLIENT_ID,
+    authority=f"https://login.microsoftonline.com/{TENANT_ID}",
+    token_cache=token_cache
+)
+
+def get_token():
+    accounts = app.get_accounts()
+    if accounts:
+        result = app.acquire_token_silent(SCOPES, account=accounts[0])
+    else:
+        flow = app.initiate_device_flow(scopes=SCOPES)
+        print(flow['message'])
+        result = app.acquire_token_by_device_flow(flow)
+    if 'access_token' in result:
+        with open(TOKEN_FILE, 'w') as f:
+            f.write(token_cache.serialize())
+        return result['access_token']
+    raise RuntimeError('Failed to acquire token')
+
+def list_recent_files(limit=5):
+    token = get_token()
+    headers = {'Authorization': f'Bearer {token}'}
+    url = 'https://graph.microsoft.com/v1.0/me/drive/recent'
+    resp = requests.get(url, headers=headers)
+    items = resp.json().get('value', [])[:limit]
+    return [{'name': i.get('name'), 'id': i.get('id')} for i in items]
+
+if __name__ == '__main__':
+    print(list_recent_files())

--- a/InsightMate/Scripts/requirements.txt
+++ b/InsightMate/Scripts/requirements.txt
@@ -1,0 +1,7 @@
+flask
+openai
+google-auth
+google-auth-oauthlib
+google-api-python-client
+requests
+msal

--- a/InsightMate/Scripts/send_imessage.py
+++ b/InsightMate/Scripts/send_imessage.py
@@ -1,0 +1,14 @@
+import subprocess
+
+
+def send_imessage(to: str, body: str):
+    script = f'''tell application "Messages"
+        send "{body}" to buddy "{to}" of (service 1 whose service type is iMessage)
+    end tell'''
+    subprocess.run(['osascript', '-e', script], check=True)
+
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) >= 3:
+        send_imessage(sys.argv[1], ' '.join(sys.argv[2:]))

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 1ucian.me
-Hello world!
-------------------
+
+This repository contains the website content as well as the **InsightMate** macOS assistant which integrates with iMessage, Gmail, Calendar and OneDrive.
+
+For setup instructions for the assistant, see [InsightMate/README.md](InsightMate/README.md).


### PR DESCRIPTION
## Summary
- integrate OneDrive access via Microsoft Graph
- allow `main.py` to accept a user question and include OneDrive data
- update the Flask server to handle user prompts and OneDrive
- add SwiftUI chat window to send questions
- document new capabilities in the README files

## Testing
- `python3 -m py_compile InsightMate/Scripts/*.py`
- `python3 -m py_compile InsightMate/InsightMateApp/Resources/py/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686eae160048833396aa869ed1b5112b