### PR TITLE
Add Electron tray chat and routing

### DIFF
--- a/InsightMate/.gitignore
+++ b/InsightMate/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+Scripts/token.json

--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -1,0 +1,26 @@
+# InsightMate
+
+InsightMate is a Windows tray assistant with a floating chat window built using Electron and Python. It connects to GPT‑4 (or Ollama if `OPENAI_API_KEY` is not set) and can search your OneDrive files, manage reminders and execute local actions. Optional Gmail and Calendar access is provided via Google OAuth.
+
+## Project Layout
+- `Scripts/` – Python backend modules
+- `electron/` – Electron tray application
+- `setup.bat` – installs dependencies and launches the app
+
+## Prerequisites
+- Windows 10 or later with Python 3 and Node.js
+- OpenAI API key exported as `OPENAI_API_KEY` (optional if using Ollama)
+- `credentials.json` in `Scripts/` for Gmail and Calendar features
+
+## Usage
+From the `InsightMate` directory run:
+
+```cmd
+setup.bat
+```
+
+This installs Python and Node dependencies, starts `chat_server.py` and opens the tray chat window. Conversations are logged to `%USERPROFILE%\InsightMate\logs\chatlog.txt`.
+
+## OneDrive Local Access
+
+`onedrive_reader.py` automatically locates your OneDrive folder and indexes text, Markdown, Word and PDF documents. Queries about your files are handled locally and results appear in the chat.

--- a/InsightMate/Scripts/action_executor.py
+++ b/InsightMate/Scripts/action_executor.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+
+def execute(command: str) -> str:
+    cmd = command.lower()
+    if 'notepad' in cmd:
+        os.startfile('notepad.exe')
+        return 'Opening Notepad.'
+    if 'spotify' in cmd:
+        subprocess.Popen(['spotify'])
+        return 'Opening Spotify.'
+    if 'open' in cmd:
+        program = cmd.split('open',1)[1].strip()
+        subprocess.Popen(program, shell=True)
+        return f'Opening {program}.'
+    return 'Action not recognized.'

--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+from typing import Optional
+import openai
+
+from onedrive_reader import search, list_word_docs
+from reminder_scheduler import schedule as schedule_reminder
+from action_executor import execute as execute_action
+
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+
+ONEDRIVE_KEYWORDS = {'onedrive', 'search', 'summarize', 'find', 'list'}
+
+
+def gpt(prompt: str) -> str:
+    if OPENAI_API_KEY:
+        openai.api_key = OPENAI_API_KEY
+        resp = openai.ChatCompletion.create(model='gpt-4', messages=[{"role": "user", "content": prompt}])
+        return resp['choices'][0]['message']['content'].strip()
+    out = subprocess.check_output(['ollama', 'run', 'llama3', prompt])
+    return out.decode().strip()
+
+
+def route(query: str) -> str:
+    q = query.lower()
+    if any(k in q for k in ONEDRIVE_KEYWORDS):
+        if 'list' in q and 'word' in q:
+            docs = list_word_docs()
+            return 'Word docs:\n' + '\n'.join(docs)
+        results = search(query)
+        if not results:
+            return 'No matching documents found.'
+        lines = []
+        for r in results:
+            snippet = f" - {r['snippet']}" if r.get('snippet') else ''
+            lines.append(f"{r['name']}{snippet}")
+        return '\n'.join(lines)
+    if 'remind me' in q or q.startswith('remind'):
+        return schedule_reminder(query)
+    if 'open' in q or 'launch' in q or 'play' in q:
+        return execute_action(query)
+    return gpt(query)
+

--- a/InsightMate/Scripts/calendar_reader.py
+++ b/InsightMate/Scripts/calendar_reader.py
@@ -1,0 +1,50 @@
+import datetime
+import os
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+TOKEN_FILE = 'token.json'
+CREDENTIALS_FILE = 'credentials.json'
+
+
+def get_credentials():
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+    return creds
+
+
+def list_today_events():
+    creds = get_credentials()
+    service = build('calendar', 'v3', credentials=creds)
+    start = datetime.datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + datetime.timedelta(days=1)
+    events_result = service.events().list(
+        calendarId='primary',
+        timeMin=start.isoformat() + 'Z',
+        timeMax=end.isoformat() + 'Z',
+        singleEvents=True,
+        orderBy='startTime'
+    ).execute()
+    events = events_result.get('items', [])
+    output = []
+    for e in events:
+        start_time = e['start'].get('dateTime', e['start'].get('date'))
+        end_time = e['end'].get('dateTime', e['end'].get('date'))
+        output.append({'title': e.get('summary', ''), 'start': start_time, 'end': end_time})
+    return output
+
+
+if __name__ == '__main__':
+    print(list_today_events())

--- a/InsightMate/Scripts/chat_server.py
+++ b/InsightMate/Scripts/chat_server.py
@@ -1,0 +1,17 @@
+import os
+from flask import Flask, request, jsonify
+from assistant_router import route
+
+app = Flask(__name__)
+
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json() or {}
+    message = data.get('message') or data.get('query') or ''
+    reply = route(message)
+    return jsonify({'reply': reply})
+
+if __name__ == '__main__':
+    app.run(port=5000)

--- a/InsightMate/Scripts/gmail_reader.py
+++ b/InsightMate/Scripts/gmail_reader.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+import os.path
+from email.header import decode_header, make_header
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+
+SCOPES = ['https://www.googleapis.com/auth/gmail.readonly',
+          'https://www.googleapis.com/auth/calendar.readonly']
+
+TOKEN_FILE = 'token.json'
+CREDENTIALS_FILE = 'credentials.json'
+
+
+def get_credentials():
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+    return creds
+
+
+def fetch_unread_email():
+    creds = get_credentials()
+    service = build('gmail', 'v1', credentials=creds)
+    results = service.users().messages().list(userId='me', labelIds=['INBOX'], q='is:unread').execute()
+    messages = results.get('messages', [])
+    if not messages:
+        return None
+    msg = service.users().messages().get(userId='me', id=messages[0]['id'], format='full').execute()
+    headers = {h['name']: str(make_header(decode_header(h['value']))) for h in msg['payload']['headers']}
+    sender = headers.get('From', '')
+    subject = headers.get('Subject', '')
+    snippet = msg.get('snippet', '')[:250]
+    return {'from': sender, 'subject': subject, 'snippet': snippet}
+
+
+if __name__ == '__main__':
+    print(fetch_unread_email())

--- a/InsightMate/Scripts/onedrive_reader.py
+++ b/InsightMate/Scripts/onedrive_reader.py
@@ -1,0 +1,103 @@
+import os
+from pathlib import Path
+from typing import List, Dict, Optional
+
+try:
+    from docx import Document
+except Exception:
+    Document = None
+
+try:
+    from PyPDF2 import PdfReader
+except Exception:
+    PdfReader = None
+
+try:
+    import textract
+except Exception:
+    textract = None
+
+ONEDRIVE_DIR = os.path.join(os.path.expanduser('~'), 'OneDrive')
+DOC_EXTS = {'.txt', '.md', '.docx', '.pdf'}
+
+
+def _iter_files() -> List[Dict[str, str]]:
+    files = []
+    if not os.path.isdir(ONEDRIVE_DIR):
+        return files
+    for root, _dirs, filenames in os.walk(ONEDRIVE_DIR):
+        for name in filenames:
+            ext = Path(name).suffix.lower()
+            if ext in DOC_EXTS:
+                path = os.path.join(root, name)
+                info = {
+                    'name': name,
+                    'path': path,
+                    'modified': os.path.getmtime(path)
+                }
+                files.append(info)
+    return files
+
+
+_def_cache: Optional[List[Dict[str, str]]] = None
+
+
+def index_files() -> List[Dict[str, str]]:
+    """Return cached list of OneDrive documents with metadata."""
+    global _def_cache
+    if _def_cache is None:
+        _def_cache = sorted(_iter_files(), key=lambda f: f['modified'], reverse=True)
+    return _def_cache
+
+
+def list_recent_files(limit: int = 5) -> List[str]:
+    """Return the most recently modified filenames."""
+    return [f['name'] for f in index_files()[:limit]]
+
+
+def extract_text(path: str) -> str:
+    """Best-effort plain text extraction."""
+    ext = Path(path).suffix.lower()
+    try:
+        if ext in {'.txt', '.md'}:
+            with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+                return f.read()
+        if ext == '.docx' and Document:
+            doc = Document(path)
+            return '\n'.join(p.text for p in doc.paragraphs)
+        if ext == '.pdf' and PdfReader:
+            reader = PdfReader(path)
+            return '\n'.join(page.extract_text() or '' for page in reader.pages)
+        if textract:
+            return textract.process(path).decode('utf-8', errors='ignore')
+    except Exception:
+        pass
+    return ''
+
+
+def search(query: str, limit: int = 5) -> List[Dict[str, str]]:
+    """Search filenames and content for the query."""
+    results = []
+    q = query.lower()
+    for info in index_files():
+        if q in info['name'].lower():
+            results.append({**info, 'snippet': ''})
+        else:
+            text = extract_text(info['path']).lower()
+            if q in text:
+                snippet_start = max(text.find(q) - 40, 0)
+                snippet = text[snippet_start: snippet_start + 160]
+                results.append({**info, 'snippet': snippet})
+        if len(results) >= limit:
+            break
+    return results
+
+
+def list_word_docs(limit: int = 20) -> List[str]:
+    return [f['name'] for f in index_files() if f['name'].lower().endswith('.docx')][:limit]
+
+
+if __name__ == '__main__':
+    for item in search('test'):
+        print(f"{item['name']} - {item['path']}")
+

--- a/InsightMate/Scripts/reminder_scheduler.py
+++ b/InsightMate/Scripts/reminder_scheduler.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from apscheduler.schedulers.background import BackgroundScheduler
+from dateparser import parse
+import win32api
+import win32con
+import win32gui
+
+scheduler = BackgroundScheduler()
+scheduler.start()
+
+def _notify(message: str):
+    try:
+        win32api.MessageBox(0, message, 'InsightMate Reminder', win32con.MB_OK)
+    except Exception:
+        pass
+
+def schedule(text: str):
+    when = parse(text, settings={'PREFER_DATES_FROM': 'future'})
+    if not when:
+        return 'Could not parse time.'
+    scheduler.add_job(_notify, 'date', run_date=when, args=[text])
+    return f'Reminder set for {when}'

--- a/InsightMate/Scripts/requirements.txt
+++ b/InsightMate/Scripts/requirements.txt
@@ -1,0 +1,13 @@
+flask
+openai
+google-auth
+google-auth-oauthlib
+google-api-python-client
+requests
+msal
+PyPDF2
+python-docx
+textract
+dateparser
+apscheduler
+pywin32

--- a/InsightMate/electron/index.html
+++ b/InsightMate/electron/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>InsightMate Chat</title>
+<style>
+  body { font-family: sans-serif; margin: 0; }
+  #messages { height: 440px; overflow-y: auto; padding: 10px; }
+  #input { width: 100%; box-sizing: border-box; }
+</style>
+</head>
+<body>
+<div id="messages"></div>
+<textarea id="input" rows="3" placeholder="Type a message..."></textarea>
+<script src="renderer.js"></script>
+</body>
+</html>

--- a/InsightMate/electron/main.js
+++ b/InsightMate/electron/main.js
@@ -1,0 +1,43 @@
+const { app, BrowserWindow, Tray, Menu } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+const fs = require('fs');
+
+let tray = null;
+let win = null;
+let serverProcess = null;
+
+function startServer() {
+  if (serverProcess) return;
+  serverProcess = spawn('python', [path.join(__dirname, '..', 'Scripts', 'chat_server.py')], { stdio: 'ignore' });
+}
+
+function createWindow() {
+  win = new BrowserWindow({
+    width: 400,
+    height: 500,
+    alwaysOnTop: true,
+    webPreferences: { nodeIntegration: true, contextIsolation: false }
+  });
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  startServer();
+  tray = new Tray(path.join(__dirname, 'icon.png'));
+  const contextMenu = Menu.buildFromTemplate([
+    { label: 'Open Chat', click: () => { if (!win) createWindow(); else win.show(); } },
+    { label: 'Quit', click: () => { app.quit(); } }
+  ]);
+  tray.setToolTip('InsightMate');
+  tray.setContextMenu(contextMenu);
+  createWindow();
+});
+
+app.on('window-all-closed', (e) => {
+  e.preventDefault();
+});
+
+app.on('before-quit', () => {
+  if (serverProcess) serverProcess.kill();
+});

--- a/InsightMate/electron/package.json
+++ b/InsightMate/electron/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "insightmate-electron",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^28.0.0",
+    "marked": "^9.0.0",
+    "node-notifier": "^10.0.1"
+  }
+}

--- a/InsightMate/electron/renderer.js
+++ b/InsightMate/electron/renderer.js
@@ -1,0 +1,45 @@
+const { ipcRenderer } = require('electron');
+const fs = require('fs');
+const path = require('path');
+const marked = require('marked');
+
+const input = document.getElementById('input');
+const messagesDiv = document.getElementById('messages');
+const logPath = path.join(require('os').homedir(), 'InsightMate', 'logs');
+if (!fs.existsSync(logPath)) fs.mkdirSync(logPath, { recursive: true });
+const logFile = path.join(logPath, 'chatlog.txt');
+
+function addMessage(sender, text) {
+  const div = document.createElement('div');
+  div.innerHTML = `<b>${sender}:</b> ` + marked.parse(text);
+  messagesDiv.appendChild(div);
+  messagesDiv.scrollTop = messagesDiv.scrollHeight;
+  fs.appendFileSync(logFile, `${sender}: ${text}\n`);
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    sendMessage();
+  }
+});
+
+document.getElementById('input').addEventListener('input', (e) => {
+  e.target.style.height = 'auto';
+  e.target.style.height = e.target.scrollHeight + 'px';
+});
+
+function sendMessage() {
+  const text = input.value.trim();
+  if (!text) return;
+  addMessage('You', text);
+  input.value = '';
+  fetch('http://localhost:5000/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: text })
+  })
+    .then(res => res.json())
+    .then(data => addMessage('Assistant', data.reply))
+    .catch(err => addMessage('Error', err.toString()));
+}

--- a/InsightMate/setup.bat
+++ b/InsightMate/setup.bat
@@ -1,0 +1,7 @@
+@echo off
+python -m venv venv
+venv\Scripts\pip install -r Scripts\requirements.txt
+start "ChatServer" venv\Scripts\python Scripts\chat_server.py
+cd electron
+npm install
+npm start

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 1ucian.me
-Hello world!
-------------------
+
+This repository contains the website content as well as **InsightMate**, a Windows tray assistant built with Electron and Python. It integrates with Gmail, Calendar and OneDrive and provides a floating chat window for chatting with GPT‑4 or Ollama.
+
+For setup instructions see [InsightMate/README.md](InsightMate/README.md).


### PR DESCRIPTION
## Summary
- remove unused macOS SwiftUI version
- drop macOS-only scripts and resources
- clean up gitignore and docs
- describe InsightMate as a Windows tray assistant

## Testing
- `python3 -m py_compile InsightMate/Scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686eae160048833396aa869ed1b5112b