### PR TITLE
Add Windows setup instructions

### DIFF
--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -43,6 +43,25 @@ python main.py "What's new?"
 
 The Flask server listens on `http://localhost:5000` and `main.py` writes the assistant reply to `/tmp/insight_output.txt`.
 
+## Windows Setup
+
+Windows users can run the same Python sources without Xcode. A helper PowerShell
+script is provided to create a virtual environment, install all requirements and
+launch the server.
+
+```powershell
+cd InsightMate\Scripts
+./windows_setup.ps1
+```
+
+The script prompts for your `OPENAI_API_KEY` if it is not already set and then
+starts `ai_server.py`. After the server is running you can invoke the main
+script:
+
+```powershell
+./venv/Scripts/python.exe main.py "What's new?"
+```
+
 ## OneDrive Local Access
 
 The `onedrive_reader.py` module automatically locates your OneDrive folder on Windows and indexes text, Markdown, Word and PDF documents. Queries about searching or listing files are routed to this reader and returned in the chat window.

--- a/InsightMate/Scripts/windows_setup.ps1
+++ b/InsightMate/Scripts/windows_setup.ps1
@@ -1,0 +1,25 @@
+# Windows setup script for InsightMate
+# Creates Python venv, installs requirements and launches the backend server.
+
+$ErrorActionPreference = 'Stop'
+
+# Path to the venv inside the Scripts folder
+$venvPath = Join-Path $PSScriptRoot 'venv'
+
+if (-Not (Test-Path $venvPath)) {
+    Write-Host "Creating Python virtual environment..."
+    python -m venv $venvPath
+}
+
+$pip = Join-Path $venvPath 'Scripts' 'pip.exe'
+Write-Host "Installing Python dependencies..."
+& $pip install -r (Join-Path $PSScriptRoot 'requirements.txt')
+
+$pythonExe = Join-Path $venvPath 'Scripts' 'python.exe'
+
+if (-not $env:OPENAI_API_KEY) {
+    $env:OPENAI_API_KEY = Read-Host -Prompt 'Enter your OpenAI API key'
+}
+
+Write-Host "Starting InsightMate server..."
+& $pythonExe ai_server.py


### PR DESCRIPTION
## Summary
- add Windows setup steps in README
- provide a PowerShell script to create a venv and launch the server

## Testing
- `python3 -m compileall InsightMate/Scripts`
- `find InsightMate/Scripts -name '*.pyc' | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_686f4919db68833387ac980bc90cb9e9