### PR TITLE
Add Windows GUI and remove macOS references

### DIFF
--- a/InsightMate/InsightMateApp/Package.swift
+++ b/InsightMate/InsightMateApp/Package.swift
@@ -5,9 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "InsightMateApp",
-    platforms: [
-        .macOS(.v11)
-    ],
     targets: [
         .executableTarget(
             name: "InsightMateApp",

--- a/InsightMate/InsightMateApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/InsightMate/InsightMateApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,7 +2,7 @@
   "images" : [
     {
       "filename" : "",
-      "idiom" : "mac",
+      "idiom" : "universal",
       "scale" : "1x",
       "size" : "512x512"
     }

--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -1,2 +1,15 @@
 # InsightMate
 
+## Windows GUI
+
+Run the simple chat interface on Windows using Python and Tkinter:
+
+```powershell
+cd Scripts
+python windows_gui.py
+```
+
+The GUI automatically starts the backend chat server and lets you send
+queries to it. Ensure that Python and required packages from
+`requirements.txt` are installed.
+

--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -1,9 +1,27 @@
+import os
+import subprocess
+from typing import Optional
+import openai
 
+from onedrive_reader import search, list_word_docs
+from reminder_scheduler import schedule as schedule_reminder
+from action_executor import execute as execute_action
+
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
 ONEDRIVE_KEYWORDS = {'onedrive', 'search', 'summarize', 'find', 'list'}
 
 
+def gpt(prompt: str) -> str:
+    if OPENAI_API_KEY:
+        openai.api_key = OPENAI_API_KEY
+        resp = openai.ChatCompletion.create(model='gpt-4', messages=[{"role": "user", "content": prompt}])
+        return resp['choices'][0]['message']['content'].strip()
+    out = subprocess.check_output(['ollama', 'run', 'llama3', prompt])
+    return out.decode().strip()
 
+
+def route(query: str) -> str:
     q = query.lower()
     if any(k in q for k in ONEDRIVE_KEYWORDS):
         if 'list' in q and 'word' in q:
@@ -17,4 +35,8 @@ ONEDRIVE_KEYWORDS = {'onedrive', 'search', 'summarize', 'find', 'list'}
             snippet = f" - {r['snippet']}" if r.get('snippet') else ''
             lines.append(f"{r['name']}{snippet}")
         return '\n'.join(lines)
-
+    if 'remind me' in q or q.startswith('remind'):
+        return schedule_reminder(query)
+    if 'open' in q or 'launch' in q or 'play' in q:
+        return execute_action(query)
+    return gpt(query)

--- a/InsightMate/Scripts/windows_gui.py
+++ b/InsightMate/Scripts/windows_gui.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import subprocess
+import threading
+import requests
+import tkinter as tk
+from tkinter.scrolledtext import ScrolledText
+
+class ChatGUI:
+    def __init__(self, root):
+        self.root = root
+        self.root.title("InsightMate")
+
+        self.text_area = ScrolledText(root, state='disabled', width=60, height=20)
+        self.text_area.pack(padx=10, pady=10)
+
+        self.entry = tk.Entry(root, width=60)
+        self.entry.pack(padx=10, pady=(0, 10))
+        self.entry.bind("<Return>", self.send_message)
+
+        self.server_proc = None
+        self.start_server()
+
+    def start_server(self):
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        if self.server_proc is None:
+            self.server_proc = subprocess.Popen(
+                [sys.executable, os.path.join(script_dir, 'chat_server.py')],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL
+            )
+
+    def add_message(self, sender, text):
+        self.text_area.configure(state='normal')
+        self.text_area.insert(tk.END, f"{sender}: {text}\n")
+        self.text_area.configure(state='disabled')
+        self.text_area.see(tk.END)
+
+    def send_message(self, event=None):
+        text = self.entry.get().strip()
+        if not text:
+            return
+        self.add_message("You", text)
+        self.entry.delete(0, tk.END)
+        threading.Thread(target=self.call_api, args=(text,)).start()
+
+    def call_api(self, text):
+        try:
+            res = requests.post("http://localhost:5000/chat", json={'query': text})
+            reply = res.json().get('reply', '')
+        except Exception as e:
+            reply = f"Error: {e}"
+        self.root.after(0, self.add_message, "Assistant", reply)
+
+    def on_close(self):
+        if self.server_proc:
+            self.server_proc.terminate()
+        self.root.destroy()
+
+if __name__ == '__main__':
+    root = tk.Tk()
+    gui = ChatGUI(root)
+    root.protocol("WM_DELETE_WINDOW", gui.on_close)
+    root.mainloop()


### PR DESCRIPTION
## Summary
- add a Tkinter-based Windows chat GUI
- document how to run the Windows GUI
- remove macOS references from the Swift package and asset files
- restore `assistant_router.py` file

## Testing
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_686f4bd970a48333a778d62ec4cc71e5