### PR TITLE
Load OpenAI API key from env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and replace with your values
+OPENAI_API_KEY=

--- a/InsightMate/InsightMateApp/Resources/py/ai_server.py
+++ b/InsightMate/InsightMateApp/Resources/py/ai_server.py
@@ -1,10 +1,12 @@
 import os
 from flask import Flask, request, jsonify
 import openai
+from dotenv import load_dotenv
 from assistant_router import route_query
 
 app = Flask(__name__)
 
+load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 @app.route('/process', methods=['POST'])

--- a/InsightMate/InsightMateApp/Resources/py/requirements.txt
+++ b/InsightMate/InsightMateApp/Resources/py/requirements.txt
@@ -9,3 +9,4 @@ PyPDF2
 python-docx
 textract
 dateparser
+python-dotenv

--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -11,5 +11,6 @@ python windows_gui.py
 
 The GUI automatically starts the backend chat server and lets you send
 queries to it. Ensure that Python and required packages from
-`requirements.txt` are installed.
+`requirements.txt` are installed. Set `OPENAI_API_KEY` in your environment or
+in a `.env` file so the assistant can access GPT-4.
 

--- a/InsightMate/Scripts/ai_server.py
+++ b/InsightMate/Scripts/ai_server.py
@@ -1,10 +1,12 @@
 import os
 from flask import Flask, request, jsonify
 import openai
+from dotenv import load_dotenv
 from assistant_router import route_query
 
 app = Flask(__name__)
 
+load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 @app.route('/process', methods=['POST'])

--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -2,11 +2,13 @@ import os
 import subprocess
 from typing import Optional
 import openai
+from dotenv import load_dotenv
 
 from onedrive_reader import search, list_word_docs
 from reminder_scheduler import schedule as schedule_reminder
 from action_executor import execute as execute_action
 
+load_dotenv()
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
 ONEDRIVE_KEYWORDS = {'onedrive', 'search', 'summarize', 'find', 'list'}

--- a/InsightMate/Scripts/chat_server.py
+++ b/InsightMate/Scripts/chat_server.py
@@ -1,9 +1,11 @@
 import os
 from flask import Flask, request, jsonify
+from dotenv import load_dotenv
 from assistant_router import route
 
 app = Flask(__name__)
 
+load_dotenv()
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
 @app.route('/chat', methods=['POST'])

--- a/InsightMate/Scripts/requirements.txt
+++ b/InsightMate/Scripts/requirements.txt
@@ -9,4 +9,5 @@ PyPDF2
 python-docx
 textract
 dateparser
+python-dotenv
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ This repository contains the source for my personal site as well as **InsightMat
 1. Install Python 3.
 2. Open `InsightMate/Scripts` in a terminal.
 3. Run `windows_setup.ps1` to create a virtual environment and launch the backend server, or run `python windows_gui.py` to open the chat window directly.
-4. When prompted, enter your `OPENAI_API_KEY`.
+4. Set `OPENAI_API_KEY` in your environment or create a `.env` file with it.
 
 See [InsightMate/README.md](InsightMate/README.md) for more details.


### PR DESCRIPTION
## Summary
- support `.env` files when loading `OPENAI_API_KEY`
- update requirements for `python-dotenv`
- document how to provide API key
- add `.env.example`

## Testing
- `python -m py_compile InsightMate/Scripts/ai_server.py InsightMate/Scripts/assistant_router.py InsightMate/Scripts/chat_server.py InsightMate/InsightMateApp/Resources/py/ai_server.py`
- `python -m pip install -q -r InsightMate/Scripts/requirements.txt` *(fails: textract setup requires pip<24.1)*

------
https://chatgpt.com/codex/tasks/task_e_686f4e7fb5008333bb042e2922e86576