### PR TITLE
Improve chat UI styling

### DIFF
--- a/InsightMate/Scripts/windows_gui.py
+++ b/InsightMate/Scripts/windows_gui.py
@@ -13,13 +13,31 @@ class ChatGUI:
     def __init__(self, root):
         self.root = root
         self.root.title("InsightMate")
+        self.root.geometry("500x600")
+        self.root.configure(bg="#2b2b2b")
         self.tray = None
 
-        self.text_area = ScrolledText(root, state='disabled', width=60, height=20)
-        self.text_area.pack(padx=10, pady=10)
+        self.text_area = ScrolledText(
+            root,
+            state="disabled",
+            width=60,
+            height=25,
+            bg="#1e1e1e",
+            fg="#ffffff",
+            insertbackground="#ffffff",
+            font=("Segoe UI", 10),
+        )
+        self.text_area.pack(padx=10, pady=10, fill=tk.BOTH, expand=True)
 
-        self.entry = tk.Entry(root, width=60)
-        self.entry.pack(padx=10, pady=(0, 10))
+        self.entry = tk.Entry(
+            root,
+            width=60,
+            bg="#2b2b2b",
+            fg="#ffffff",
+            insertbackground="#ffffff",
+            font=("Segoe UI", 10),
+        )
+        self.entry.pack(padx=10, pady=(0, 10), fill=tk.X)
         self.entry.bind("<Return>", self.send_message)
 
         self.server_proc = None

--- a/InsightMate/electron/index.html
+++ b/InsightMate/electron/index.html
@@ -4,9 +4,48 @@
 <meta charset="UTF-8">
 <title>InsightMate Chat</title>
 <style>
-  body { font-family: sans-serif; margin: 0; }
-  #messages { height: 440px; overflow-y: auto; padding: 10px; }
-  #input { width: 100%; box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, sans-serif;
+    background: #1e1e1e;
+    color: #ddd;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+  }
+  #messages {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px;
+  }
+  textarea {
+    border: none;
+    resize: none;
+    padding: 10px;
+    font-family: inherit;
+    font-size: 14px;
+    background: #252526;
+    color: #ddd;
+  }
+  .message {
+    margin-bottom: 8px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    max-width: 80%;
+    line-height: 1.4;
+  }
+  .message.you {
+    background: #0078d4;
+    color: #fff;
+    align-self: flex-end;
+  }
+  .message.assistant {
+    background: #333;
+    color: #fff;
+    align-self: flex-start;
+  }
 </style>
 </head>
 <body>

--- a/InsightMate/electron/renderer.js
+++ b/InsightMate/electron/renderer.js
@@ -11,7 +11,8 @@ const logFile = path.join(logPath, 'chatlog.txt');
 
 function addMessage(sender, text) {
   const div = document.createElement('div');
-  div.innerHTML = `<b>${sender}:</b> ` + marked.parse(text);
+  div.classList.add('message', sender === 'You' ? 'you' : 'assistant');
+  div.innerHTML = `<strong>${sender}:</strong> ` + marked.parse(text);
   messagesDiv.appendChild(div);
   messagesDiv.scrollTop = messagesDiv.scrollHeight;
   fs.appendFileSync(logFile, `${sender}: ${text}\n`);


### PR DESCRIPTION
## Summary
- modernize the Tkinter chat window with a dark theme
- restyle the Electron chat page with dark colors and chat bubbles
- render messages with CSS classes in renderer.js

## Testing
- `python -m py_compile InsightMate/Scripts/windows_gui.py`
- `node -c InsightMate/electron/renderer.js`


------
https://chatgpt.com/codex/tasks/task_e_686f5b5bd40c8333a51a8fcb45ff33ab