### PR TITLE
Improve OneDrive cache

### DIFF
--- a/InsightMate/InsightMateApp/Resources/py/onedrive_reader.py
+++ b/InsightMate/InsightMateApp/Resources/py/onedrive_reader.py
@@ -39,14 +39,13 @@ def _iter_files() -> List[Dict[str, str]]:
     return files
 
 
-_def_cache: Optional[List[Dict[str, str]]] = None
+from functools import lru_cache
 
 
+@lru_cache(maxsize=1)
 def index_files() -> List[Dict[str, str]]:
-    global _def_cache
-    if _def_cache is None:
-        _def_cache = sorted(_iter_files(), key=lambda f: f['modified'], reverse=True)
-    return _def_cache
+    """Return cached list of OneDrive documents with metadata."""
+    return sorted(_iter_files(), key=lambda f: f['modified'], reverse=True)
 
 
 def extract_text(path: str) -> str:

--- a/InsightMate/Scripts/onedrive_reader.py
+++ b/InsightMate/Scripts/onedrive_reader.py
@@ -39,15 +39,13 @@ def _iter_files() -> List[Dict[str, str]]:
     return files
 
 
-_def_cache: Optional[List[Dict[str, str]]] = None
+from functools import lru_cache
 
 
+@lru_cache(maxsize=1)
 def index_files() -> List[Dict[str, str]]:
     """Return cached list of OneDrive documents with metadata."""
-    global _def_cache
-    if _def_cache is None:
-        _def_cache = sorted(_iter_files(), key=lambda f: f['modified'], reverse=True)
-    return _def_cache
+    return sorted(_iter_files(), key=lambda f: f['modified'], reverse=True)
 
 
 


### PR DESCRIPTION
## Summary
- cache OneDrive file listing using lru_cache

## Testing
- `python3 -m py_compile $(find InsightMate -name '*.py')`
- `python3 -m pip install -q -r InsightMate/Scripts/requirements.txt` *(fails: invalid metadata for textract)*

------
https://chatgpt.com/codex/tasks/task_e_686fffc1eb88833383c68363608e1ccc