### PR TITLE
Add persistent local memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+InsightMate/Scripts/memory.db

--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -32,3 +32,7 @@ Minimizing the window hides it to the system tray so InsightMate can keep
 running in the background. Right‑click the tray icon to quit or open the
 chat window again.
 
+InsightMate keeps a local SQLite database named `memory.db` in the `Scripts`
+folder. It records your chat history as well as any emails or calendar events
+that were read during a session.
+

--- a/InsightMate/Scripts/memory_db.py
+++ b/InsightMate/Scripts/memory_db.py
@@ -1,0 +1,86 @@
+import os
+import sqlite3
+from typing import List, Tuple, Dict
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'memory.db')
+
+
+def _connect():
+    return sqlite3.connect(DB_PATH)
+
+
+def init_db():
+    conn = _connect()
+    c = conn.cursor()
+    c.execute(
+        'CREATE TABLE IF NOT EXISTS messages ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+        'ts DATETIME DEFAULT CURRENT_TIMESTAMP,'
+        'sender TEXT,'
+        'text TEXT'
+        ')'
+    )
+    c.execute(
+        'CREATE TABLE IF NOT EXISTS emails ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+        'ts DATETIME DEFAULT CURRENT_TIMESTAMP,'
+        'sender TEXT,'
+        'subject TEXT,'
+        'snippet TEXT'
+        ')'
+    )
+    c.execute(
+        'CREATE TABLE IF NOT EXISTS calendar_events ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+        'ts DATETIME DEFAULT CURRENT_TIMESTAMP,'
+        'title TEXT,'
+        'start TEXT,'
+        'end TEXT'
+        ')'
+    )
+    conn.commit()
+    conn.close()
+
+
+init_db()
+
+
+def save_message(sender: str, text: str) -> None:
+    conn = _connect()
+    conn.execute('INSERT INTO messages(sender, text) VALUES (?, ?)', (sender, text))
+    conn.commit()
+    conn.close()
+
+
+def save_email(email: Dict[str, str]) -> None:
+    if not email:
+        return
+    conn = _connect()
+    conn.execute(
+        'INSERT INTO emails(sender, subject, snippet) VALUES (?, ?, ?)',
+        (email.get('from', ''), email.get('subject', ''), email.get('snippet', ''))
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_calendar_events(events: List[Dict[str, str]]) -> None:
+    if not events:
+        return
+    conn = _connect()
+    for e in events:
+        conn.execute(
+            'INSERT INTO calendar_events(title, start, end) VALUES (?, ?, ?)',
+            (e.get('title', ''), e.get('start', ''), e.get('end', ''))
+        )
+    conn.commit()
+    conn.close()
+
+
+def get_recent_messages(limit: int = 20) -> List[Tuple[str, str, str]]:
+    conn = _connect()
+    c = conn.cursor()
+    c.execute('SELECT ts, sender, text FROM messages ORDER BY id DESC LIMIT ?', (limit,))
+    rows = c.fetchall()
+    conn.close()
+    return rows

--- a/README.md
+++ b/README.md
@@ -20,5 +20,7 @@ This repository contains the source for my personal site as well as **InsightMat
    background. Use the tray icon to restore or quit InsightMate.
 8. If the chat window shows connection errors, check
    `InsightMate/Scripts/chat_server.log` for details.
+9. Conversation history, unread email summaries and calendar events are stored
+   locally in `InsightMate/Scripts/memory.db`.
 
 See [InsightMate/README.md](InsightMate/README.md) for more details.


### PR DESCRIPTION
## Summary
- add new `memory_db` module storing chats, emails, and calendar events in `memory.db`
- store user/assistant messages and fetched data via `assistant_router`
- document local memory database in both READMEs
- ignore the generated database file

## Testing
- `python -m py_compile InsightMate/Scripts/memory_db.py`
- `python -m py_compile InsightMate/Scripts/assistant_router.py`


------
https://chatgpt.com/codex/tasks/task_e_687032b4e2808333b27cd7243d8fe083