### PR TITLE
Add dynamic task scheduler and UI

### DIFF
--- a/InsightMate/Scripts/chat_server.py
+++ b/InsightMate/Scripts/chat_server.py
@@ -2,6 +2,7 @@ import os
 from flask import Flask, request, jsonify
 from dotenv import load_dotenv
 from assistant_router import route
+from reminder_scheduler import list_reminders, list_tasks
 
 app = Flask(__name__)
 
@@ -14,6 +15,20 @@ def chat():
     message = data.get('message') or data.get('query') or ''
     reply = route(message)
     return jsonify({'reply': reply})
+
+
+@app.route('/reminders', methods=['GET'])
+def reminders():
+    rems = list_reminders()
+    data = [{'id': r[0], 'text': r[1], 'time': r[2]} for r in rems]
+    return jsonify({'reminders': data})
+
+
+@app.route('/tasks', methods=['GET'])
+def tasks():
+    tasks = list_tasks()
+    data = [{'id': t[0], 'type': t[1], 'description': t[2], 'schedule': t[3]} for t in tasks]
+    return jsonify({'tasks': data})
 
 if __name__ == '__main__':
     app.run(port=5000)

--- a/InsightMate/Scripts/memory_db.py
+++ b/InsightMate/Scripts/memory_db.py
@@ -38,6 +38,23 @@ def init_db():
         'end TEXT'
         ')'
     )
+    c.execute(
+        'CREATE TABLE IF NOT EXISTS reminders ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+        'ts DATETIME DEFAULT CURRENT_TIMESTAMP,'
+        'text TEXT,'
+        'run_time TEXT'
+        ')'
+    )
+    c.execute(
+        'CREATE TABLE IF NOT EXISTS tasks ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+        'ts DATETIME DEFAULT CURRENT_TIMESTAMP,'
+        'type TEXT,'
+        'description TEXT,'
+        'schedule TEXT'
+        ')'
+    )
     conn.commit()
     conn.close()
 
@@ -81,6 +98,41 @@ def get_recent_messages(limit: int = 20) -> List[Tuple[str, str, str]]:
     conn = _connect()
     c = conn.cursor()
     c.execute('SELECT ts, sender, text FROM messages ORDER BY id DESC LIMIT ?', (limit,))
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+
+def save_reminder(text: str, run_time: str) -> None:
+    conn = _connect()
+    conn.execute('INSERT INTO reminders(text, run_time) VALUES (?, ?)', (text, run_time))
+    conn.commit()
+    conn.close()
+
+
+def list_reminders() -> List[Tuple[int, str, str]]:
+    conn = _connect()
+    c = conn.cursor()
+    c.execute('SELECT id, text, run_time FROM reminders ORDER BY run_time')
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+
+def save_task(task_type: str, description: str, schedule: str) -> None:
+    conn = _connect()
+    conn.execute(
+        'INSERT INTO tasks(type, description, schedule) VALUES (?, ?, ?)',
+        (task_type, description, schedule)
+    )
+    conn.commit()
+    conn.close()
+
+
+def list_tasks() -> List[Tuple[int, str, str, str]]:
+    conn = _connect()
+    c = conn.cursor()
+    c.execute('SELECT id, type, description, schedule FROM tasks ORDER BY id')
     rows = c.fetchall()
     conn.close()
     return rows

--- a/InsightMate/Scripts/reminder_scheduler.py
+++ b/InsightMate/Scripts/reminder_scheduler.py
@@ -1,6 +1,18 @@
 from datetime import datetime
 from apscheduler.schedulers.background import BackgroundScheduler
 from dateparser import parse
+from typing import List, Tuple
+import os
+import requests
+
+from memory_db import (
+    save_reminder,
+    list_reminders as db_list_reminders,
+    save_task,
+    list_tasks as db_list_tasks,
+)
+from gmail_reader import fetch_unread_email
+from calendar_reader import list_today_events
 
 try:
     import win32api
@@ -21,9 +33,103 @@ def _notify(message: str):
     else:
         print(f"Reminder: {message}")
 
-def schedule(text: str):
+def schedule(text: str) -> str:
     when = parse(text, settings={'PREFER_DATES_FROM': 'future'})
     if not when:
         return 'Could not parse time.'
     scheduler.add_job(_notify, 'date', run_date=when, args=[text])
+    save_reminder(text, when.isoformat())
     return f'Reminder set for {when}'
+
+
+def _air_quality_job():
+    lat = os.getenv('LATITUDE', '52.52')
+    lon = os.getenv('LONGITUDE', '13.41')
+    url = (
+        'https://air-quality-api.open-meteo.com/v1/air-quality'
+        f'?latitude={lat}&longitude={lon}&hourly=pm2_5'
+    )
+    try:
+        data = requests.get(url, timeout=10).json()
+        value = data.get('hourly', {}).get('pm2_5', [None])[0]
+        if value is None:
+            msg = 'Could not fetch air quality data.'
+        elif value > 35:
+            msg = f'PM2.5 is {value} µg/m³. Close the windows.'
+        else:
+            msg = f'PM2.5 is {value} µg/m³. You can open the windows.'
+    except Exception as e:
+        msg = f'Error checking air quality: {e}'
+    _notify(msg)
+
+
+def _weather_job():
+    lat = os.getenv('LATITUDE', '52.52')
+    lon = os.getenv('LONGITUDE', '13.41')
+    url = (
+        'https://api.open-meteo.com/v1/forecast'
+        f'?latitude={lat}&longitude={lon}&current_weather=true'
+    )
+    try:
+        data = requests.get(url, timeout=10).json()
+        weather = data.get('current_weather', {})
+        temp = weather.get('temperature')
+        code = weather.get('weathercode')
+        msg = f'Weather {temp}°C, code {code}' if temp is not None else 'Could not fetch weather.'
+    except Exception as e:
+        msg = f'Error checking weather: {e}'
+    _notify(msg)
+
+
+def _email_job():
+    email = fetch_unread_email()
+    if email:
+        msg = f"Email from {email['from']}: {email['subject']}"
+    else:
+        msg = 'No unread email.'
+    _notify(msg)
+
+
+def _calendar_job():
+    events = list_today_events()
+    if events:
+        lines = [f"{e['start']} {e['title']}" for e in events]
+        msg = '\n'.join(lines)
+    else:
+        msg = 'No events today.'
+    _notify(msg)
+
+
+def schedule_air_quality(text: str) -> str:
+    when = parse(text, settings={'PREFER_DATES_FROM': 'future'})
+    if not when:
+        return 'Could not parse time.'
+    scheduler.add_job(_air_quality_job, 'date', run_date=when)
+    save_reminder(f'Air quality check at {when}', when.isoformat())
+    return f'Air quality check scheduled for {when}'
+
+
+def schedule_weather(interval_minutes: int) -> str:
+    scheduler.add_job(_weather_job, 'interval', minutes=interval_minutes)
+    save_task('weather', 'Weather update', f'every {interval_minutes}m')
+    return f'Weather checks every {interval_minutes} minutes scheduled'
+
+
+def schedule_email(interval_minutes: int) -> str:
+    scheduler.add_job(_email_job, 'interval', minutes=interval_minutes)
+    save_task('email', 'Email check', f'every {interval_minutes}m')
+    return f'Email checks every {interval_minutes} minutes scheduled'
+
+
+def schedule_calendar(interval_minutes: int) -> str:
+    scheduler.add_job(_calendar_job, 'interval', minutes=interval_minutes)
+    save_task('calendar', 'Calendar check', f'every {interval_minutes}m')
+    return f'Calendar checks every {interval_minutes} minutes scheduled'
+
+
+def list_reminders() -> List[Tuple[int, str, str]]:
+    return db_list_reminders()
+
+
+def list_tasks() -> List[Tuple[int, str, str, str]]:
+    return db_list_tasks()

--- a/InsightMate/electron/index.html
+++ b/InsightMate/electron/index.html
@@ -9,9 +9,16 @@
     font-family: 'Segoe UI', Tahoma, sans-serif;
     background: #1e1e1e;
     color: #ddd;
+    height: 100vh;
+  }
+  #container {
+    display: flex;
+    height: 100vh;
+  }
+  #chat {
+    flex: 1;
     display: flex;
     flex-direction: column;
-    height: 100vh;
   }
   #messages {
     display: flex;
@@ -19,6 +26,22 @@
     flex: 1;
     overflow-y: auto;
     padding: 10px;
+  }
+  #reminders {
+    width: 200px;
+    padding: 10px;
+    overflow-y: auto;
+    background: #2b2b2b;
+  }
+  #tasks {
+    width: 200px;
+    padding: 10px;
+    overflow-y: auto;
+    background: #2b2b2b;
+  }
+  .reminder-item {
+    font-size: 12px;
+    margin-bottom: 8px;
   }
   textarea {
     border: none;
@@ -49,8 +72,20 @@
 </style>
 </head>
 <body>
-<div id="messages"></div>
-<textarea id="input" rows="3" placeholder="Type a message..."></textarea>
+<div id="container">
+  <div id="chat">
+    <div id="messages"></div>
+    <textarea id="input" rows="3" placeholder="Type a message..."></textarea>
+  </div>
+  <div id="reminders">
+    <h3>Reminders</h3>
+    <div id="reminder-list"></div>
+  </div>
+  <div id="tasks">
+    <h3>Tasks</h3>
+    <div id="task-list"></div>
+  </div>
+</div>
 <script src="renderer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend the memory DB with a `tasks` table and helpers
- allow scheduling of recurring weather, email and calendar checks
- expose `/tasks` API endpoint and display tasks in Electron
- parse user commands to create and list scheduled tasks

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node -c InsightMate/electron/renderer.js`
- `node -c InsightMate/electron/main.js`


------
https://chatgpt.com/codex/tasks/task_e_687034891b7083338c5f532324eabe1c