### PR TITLE
Add memory viewer and O4-mini support

### DIFF
--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -18,7 +18,7 @@ queries to it. If you see connection errors, the server may have failed to
 start. Check `Scripts/chat_server.log` for any errors.
 
 Copy `.env.example` to `.env`. Set `OPENAI_API_KEY` only if you want to use
-GPT‑4o or GPT‑4; leaving it blank will route chat requests to the local Llama 3 model via
+GPT‑4o, GPT‑4, **o4-mini** or **o4-mini-high**; leaving it blank will route chat requests to the local Llama 3 model via
 [Ollama](https://ollama.ai/).
 
 `windows_setup.ps1` will automatically download the Llama 3 model with
@@ -38,4 +38,6 @@ and `pyaudio`, you can dictate commands instead of typing them.
 InsightMate keeps a local SQLite database named `memory.db` in the `Scripts`
 folder. It records your chat history as well as any emails or calendar events
 that were read during a session.
+The desktop UI now includes a **Memory** column to view recent messages along
+with sections for reminders and scheduled tasks.
 

--- a/InsightMate/Scripts/chat_server.py
+++ b/InsightMate/Scripts/chat_server.py
@@ -3,6 +3,7 @@ from flask import Flask, request, jsonify
 from dotenv import load_dotenv
 from assistant_router import route
 from reminder_scheduler import list_reminders, list_tasks
+from memory_db import get_recent_messages
 
 app = Flask(__name__)
 
@@ -29,6 +30,16 @@ def tasks():
     tasks = list_tasks()
     data = [{'id': t[0], 'type': t[1], 'description': t[2], 'schedule': t[3]} for t in tasks]
     return jsonify({'tasks': data})
+
+
+@app.route('/memory', methods=['GET'])
+def memory():
+    messages = get_recent_messages()
+    data = [
+        {'ts': m[0], 'sender': m[1], 'text': m[2]}
+        for m in messages
+    ]
+    return jsonify({'messages': data})
 
 if __name__ == '__main__':
     app.run(port=5000)

--- a/InsightMate/Scripts/windows_gui.py
+++ b/InsightMate/Scripts/windows_gui.py
@@ -171,7 +171,7 @@ class ChatGUI:
 
         tk.Label(win, text='LLM:').grid(row=1, column=0, sticky='w')
         llm_box = ttk.Combobox(win, textvariable=llm_var,
-                               values=['gpt-4o', 'gpt-4', 'llama3'],
+                               values=['gpt-4o', 'gpt-4', 'o4-mini', 'o4-mini-high', 'llama3'],
                                state='readonly')
         llm_box.grid(row=1, column=1, padx=5, pady=5)
 

--- a/InsightMate/electron/index.html
+++ b/InsightMate/electron/index.html
@@ -39,6 +39,12 @@
     overflow-y: auto;
     background: #2b2b2b;
   }
+  #memory {
+    width: 250px;
+    padding: 10px;
+    overflow-y: auto;
+    background: #2b2b2b;
+  }
   .reminder-item {
     font-size: 12px;
     margin-bottom: 8px;
@@ -84,6 +90,10 @@
   <div id="tasks">
     <h3>Tasks</h3>
     <div id="task-list"></div>
+  </div>
+  <div id="memory">
+    <h3>Memory</h3>
+    <div id="memory-list"></div>
   </div>
 </div>
 <script src="renderer.js"></script>

--- a/InsightMate/electron/renderer.js
+++ b/InsightMate/electron/renderer.js
@@ -7,6 +7,7 @@ const input = document.getElementById('input');
 const messagesDiv = document.getElementById('messages');
 const reminderDiv = document.getElementById('reminder-list');
 const taskDiv = document.getElementById('task-list');
+const memoryDiv = document.getElementById('memory-list');
 const logPath = path.join(require('os').homedir(), 'InsightMate', 'logs');
 if (!fs.existsSync(logPath)) fs.mkdirSync(logPath, { recursive: true });
 const logFile = path.join(logPath, 'chatlog.txt');
@@ -40,6 +41,16 @@ function renderTasks(items) {
   });
 }
 
+function renderMemory(items) {
+  memoryDiv.innerHTML = '';
+  items.forEach(m => {
+    const d = document.createElement('div');
+    d.className = 'reminder-item';
+    d.textContent = `${m.sender}: ${m.text}`;
+    memoryDiv.appendChild(d);
+  });
+}
+
 function fetchReminders() {
   fetch('http://localhost:5000/reminders')
     .then(res => res.json())
@@ -49,6 +60,11 @@ function fetchReminders() {
   fetch('http://localhost:5000/tasks')
     .then(res => res.json())
     .then(data => renderTasks(data.tasks || []))
+    .catch(() => {});
+
+  fetch('http://localhost:5000/memory')
+    .then(res => res.json())
+    .then(data => renderMemory(data.messages || []))
     .catch(() => {});
 }
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This repository contains the source for my personal site as well as **InsightMat
 7. Minimizing the chat window hides it to the system tray so it can run in the
    background. Use the tray icon to restore or quit InsightMate.
 8. Open the **Settings** window (via the tray menu or button) to update your API
-   key, choose between GPT‑4o, GPT‑4 or Llama 3, and switch themes.
+   key, choose between GPT‑4o, GPT‑4, **o4-mini**, **o4-mini-high** or Llama 3,
+   and switch themes.
 9. Use the **Voice** button to dictate a query if `speech_recognition` and
    `pyaudio` are installed.
 10. If the chat window shows connection errors, check
@@ -28,5 +29,7 @@ This repository contains the source for my personal site as well as **InsightMat
 11. Conversation history, unread email summaries and calendar events are stored
     locally in `InsightMate/Scripts/memory.db`. Settings are written to
     `InsightMate/Scripts/config.json`.
+12. The Electron UI now shows **Reminders**, **Tasks** and a **Memory** panel so
+    you can review scheduled jobs and recent conversations.
 
 See [InsightMate/README.md](InsightMate/README.md) for more details.


### PR DESCRIPTION
## Summary
- expose recent memory via `/memory` endpoint
- support `o4-mini` and `o4-mini-high` models in assistant router
- display memory in the Electron UI
- list `o4-mini` options in the Windows GUI
- document new models and memory panel

## Testing
- `python -m py_compile InsightMate/Scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6870416ac6d083339c146fe939524f3a