### PR TITLE
Add conversation memory

### DIFF
--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -40,6 +40,8 @@ and `pyaudio`, you can dictate commands instead of typing them.
 InsightMate keeps a local SQLite database named `memory.db` in the `Scripts`
 folder. It records your chat history as well as any emails or calendar events
 that were read during a session.
-The desktop UI now includes a **Memory** column to view recent messages along
-with sections for reminders and scheduled tasks.
+The last few exchanges are also sent back to your chosen model so it can
+respond with awareness of previous messages. The desktop UI includes a
+**Memory** column to review recent messages along with sections for reminders
+and scheduled tasks.
 

--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -48,19 +48,25 @@ def gpt(prompt: str) -> str:
     cfg = _get_config()
     llm = get_llm(cfg).lower()
     api_key = get_api_key(cfg)
-    if llm in {'gpt-4', 'gpt-4o', 'o4-mini', 'o4-mini-high'}:
+    history = get_recent_messages(10)
+    messages = [{"role": m[1], "content": m[2]} for m in history]
+    messages.append({"role": "user", "content": prompt})
+    if llm in {"gpt-4", "gpt-4o", "o4-mini", "o4-mini-high"}:
         if not api_key:
-            return 'OpenAI API key missing.'
+            return "OpenAI API key missing."
         openai.api_key = api_key
-        if llm == 'gpt-4o':
-            model = 'gpt-4o'
-        elif llm == 'gpt-4':
-            model = 'gpt-4'
+        if llm == "gpt-4o":
+            model = "gpt-4o"
+        elif llm == "gpt-4":
+            model = "gpt-4"
         else:
             model = llm
-        return chat_completion(model, [{"role": "user", "content": prompt}])
-    model = llm if llm else 'llama3'
-    out = subprocess.check_output(['ollama', 'run', model, prompt])
+        return chat_completion(model, messages)
+    model = llm if llm else "llama3"
+    text = "\n".join(
+        f"{m['role'].capitalize()}: {m['content']}" for m in messages
+    )
+    out = subprocess.check_output(["ollama", "run", model, text])
     return out.decode().strip()
 
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ This repository contains the source for my personal site as well as **InsightMat
 10. Use the **Voice** button to dictate a query if `speech_recognition` and `pyaudio` are installed.
 11. If the chat window shows connection errors, check `InsightMate/Scripts/chat_server.log` for details.
 12. Conversation history, unread email summaries and calendar events are stored locally in `InsightMate/Scripts/memory.db`. Settings are written to `InsightMate/Scripts/config.json`.
-13. To launch the Electron interface manually after the chat server is running, change to `InsightMate/electron` and run `npm start`. `setup.bat` performs this automatically when you run it.
-14. The Electron UI now shows **Reminders**, **Tasks** and a **Memory** panel so you can review scheduled jobs and recent conversations.
+13. The last few messages are sent to GPT‑4o, GPT‑4 or Llama 3 so chats keep their context across runs.
+14. To launch the Electron interface manually after the chat server is running, change to `InsightMate/electron` and run `npm start`. `setup.bat` performs this automatically when you run it.
+15. The Electron UI now shows **Reminders**, **Tasks** and a **Memory** panel so you can review scheduled jobs and recent conversations.
 
 See [InsightMate/README.md](InsightMate/README.md) for more details.
 


### PR DESCRIPTION
## Summary
- keep the last few messages in memory and send them to GPT or Ollama
- update README instructions to explain that context is preserved

## Testing
- `python -m py_compile InsightMate/Scripts/assistant_router.py`

------
https://chatgpt.com/codex/tasks/task_e_68705f9c51e483339abf2691ddf09143