### PR TITLE
Add shared Google OAuth helper

### DIFF
--- a/InsightMate/InsightMateApp/Resources/py/calendar_reader.py
+++ b/InsightMate/InsightMateApp/Resources/py/calendar_reader.py
@@ -1,28 +1,7 @@
 import datetime
-import os
-from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 
-SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
-TOKEN_FILE = 'token.json'
-CREDENTIALS_FILE = 'credentials.json'
-
-
-def get_credentials():
-    creds = None
-    if os.path.exists(TOKEN_FILE):
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
-            creds = flow.run_local_server(port=0)
-        with open(TOKEN_FILE, 'w') as token:
-            token.write(creds.to_json())
-    return creds
+from google_auth import get_credentials
 
 
 def list_today_events():

--- a/InsightMate/InsightMateApp/Resources/py/gmail_reader.py
+++ b/InsightMate/InsightMateApp/Resources/py/gmail_reader.py
@@ -1,31 +1,8 @@
 from __future__ import print_function
-import os.path
 from email.header import decode_header, make_header
-from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
 
-SCOPES = ['https://www.googleapis.com/auth/gmail.readonly',
-          'https://www.googleapis.com/auth/calendar.readonly']
-
-TOKEN_FILE = 'token.json'
-CREDENTIALS_FILE = 'credentials.json'
-
-
-def get_credentials():
-    creds = None
-    if os.path.exists(TOKEN_FILE):
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
-            creds = flow.run_local_server(port=0)
-        with open(TOKEN_FILE, 'w') as token:
-            token.write(creds.to_json())
-    return creds
+from google_auth import get_credentials
 
 
 def fetch_unread_email():

--- a/InsightMate/InsightMateApp/Resources/py/google_auth.py
+++ b/InsightMate/InsightMateApp/Resources/py/google_auth.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+import os.path
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+SCOPES = [
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/calendar.readonly',
+]
+TOKEN_FILE = 'token.json'
+CREDENTIALS_FILE = 'credentials.json'
+
+def get_credentials():
+    """Return authorized Google credentials for Gmail and Calendar."""
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+    return creds

--- a/InsightMate/Scripts/calendar_reader.py
+++ b/InsightMate/Scripts/calendar_reader.py
@@ -1,28 +1,7 @@
 import datetime
-import os
-from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 
-SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
-TOKEN_FILE = 'token.json'
-CREDENTIALS_FILE = 'credentials.json'
-
-
-def get_credentials():
-    creds = None
-    if os.path.exists(TOKEN_FILE):
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
-            creds = flow.run_local_server(port=0)
-        with open(TOKEN_FILE, 'w') as token:
-            token.write(creds.to_json())
-    return creds
+from google_auth import get_credentials
 
 
 def list_today_events():

--- a/InsightMate/Scripts/gmail_reader.py
+++ b/InsightMate/Scripts/gmail_reader.py
@@ -1,31 +1,8 @@
 from __future__ import print_function
-import os.path
 from email.header import decode_header, make_header
-from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
 
-SCOPES = ['https://www.googleapis.com/auth/gmail.readonly',
-          'https://www.googleapis.com/auth/calendar.readonly']
-
-TOKEN_FILE = 'token.json'
-CREDENTIALS_FILE = 'credentials.json'
-
-
-def get_credentials():
-    creds = None
-    if os.path.exists(TOKEN_FILE):
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
-            creds = flow.run_local_server(port=0)
-        with open(TOKEN_FILE, 'w') as token:
-            token.write(creds.to_json())
-    return creds
+from google_auth import get_credentials
 
 
 def fetch_unread_email():

--- a/InsightMate/Scripts/google_auth.py
+++ b/InsightMate/Scripts/google_auth.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+import os.path
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+SCOPES = [
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/calendar.readonly',
+]
+TOKEN_FILE = 'token.json'
+CREDENTIALS_FILE = 'credentials.json'
+
+def get_credentials():
+    """Return authorized Google credentials for Gmail and Calendar."""
+    creds = None
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+    return creds


### PR DESCRIPTION
## Summary
- create `google_auth.py` to share Gmail/Calendar OAuth logic
- simplify `gmail_reader.py` and `calendar_reader.py` to use the helper
- mirror changes in macOS Resources scripts

## Testing
- `python -m py_compile InsightMate/Scripts/*.py InsightMate/InsightMateApp/Resources/py/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68706fdfe97483339c24969ebdd7b802