### PR TITLE
Switch default model to qwen3

### DIFF
--- a/InsightMate/README.md
+++ b/InsightMate/README.md
@@ -20,11 +20,11 @@ queries to it. If you see connection errors, the server may have failed to
 start. Check `Scripts/chat_server.log` for any errors.
 
 Copy `.env.example` to `.env`. Set `OPENAI_API_KEY` only if you want to use
-GPT‑4o, GPT‑4, **o4-mini** or **o4-mini-high**; leaving it blank will route chat requests to the local Llama 3 model via
+GPT‑4o, GPT‑4, **o4-mini** or **o4-mini-high**; leaving it blank will route chat requests to the local Qwen3 model via
 [Ollama](https://ollama.ai/).
 
-`windows_setup.ps1` will automatically download the Llama 3 model with
-`ollama pull llama3` as long as Ollama is installed.
+`windows_setup.ps1` will automatically download the Qwen3 model with
+`ollama pull qwen3:30b-a3b` as long as Ollama is installed.
 
 Place your Google API `credentials.json` in this directory and run
 `python gmail_reader.py` once to authorize Gmail and Calendar access. The

--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -62,7 +62,7 @@ def gpt(prompt: str) -> str:
         else:
             model = llm
         return chat_completion(model, messages)
-    model = llm if llm else "llama3"
+    model = llm if llm else "qwen3:30b-a3b"
     text = "\n".join(
         f"{m['role'].capitalize()}: {m['content']}" for m in messages
     )

--- a/InsightMate/Scripts/config.py
+++ b/InsightMate/Scripts/config.py
@@ -4,7 +4,7 @@ import os
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config.json')
 DEFAULT_CONFIG = {
     'api_key': '',
-    'llm': 'llama3',
+    'llm': 'qwen3:30b-a3b',
     'theme': 'dark'
 }
 

--- a/InsightMate/Scripts/windows_gui.py
+++ b/InsightMate/Scripts/windows_gui.py
@@ -188,7 +188,7 @@ class ChatGUI:
         win = tk.Toplevel(self.root)
         win.title('Settings')
         api_var = tk.StringVar(value=self.config.get('api_key', ''))
-        llm_var = tk.StringVar(value=self.config.get('llm', 'llama3'))
+        llm_var = tk.StringVar(value=self.config.get('llm', 'qwen3:30b-a3b'))
         theme_var = tk.StringVar(value=self.config.get('theme', 'dark'))
 
         tk.Label(win, text='OpenAI API Key:').grid(row=0, column=0, sticky='w')
@@ -197,7 +197,7 @@ class ChatGUI:
 
         tk.Label(win, text='LLM:').grid(row=1, column=0, sticky='w')
         llm_box = ttk.Combobox(win, textvariable=llm_var,
-                               values=['gpt-4o', 'gpt-4', 'o4-mini', 'o4-mini-high', 'llama3'],
+                               values=['gpt-4o', 'gpt-4', 'o4-mini', 'o4-mini-high', 'qwen3:30b-a3b'],
                                state='readonly')
         llm_box.grid(row=1, column=1, padx=5, pady=5)
 

--- a/InsightMate/Scripts/windows_setup.ps1
+++ b/InsightMate/Scripts/windows_setup.ps1
@@ -15,12 +15,12 @@ $pip = Join-Path $venvPath 'Scripts' 'pip.exe'
 Write-Host "Installing Python dependencies..."
 & $pip install -r (Join-Path $PSScriptRoot 'requirements.txt')
 
-# Download the local Llama 3 model if Ollama is available
+# Download the local Qwen3 model if Ollama is available
 if (Get-Command 'ollama' -ErrorAction SilentlyContinue) {
-    Write-Host "Downloading Llama 3 model via Ollama..."
-    ollama pull llama3
+    Write-Host "Downloading Qwen3 model via Ollama..."
+    ollama pull qwen3:30b-a3b
 } else {
-    Write-Warning "Ollama is not installed. Install it from https://ollama.ai/ to run Llama 3 locally."
+    Write-Warning "Ollama is not installed. Install it from https://ollama.ai/ to run Qwen3 locally."
 }
 
 $pythonExe = Join-Path $venvPath 'Scripts' 'python.exe'

--- a/InsightMate/electron/index.html
+++ b/InsightMate/electron/index.html
@@ -165,7 +165,7 @@
       <select id="model-select">
         <option value="gpt-4o">GPT-4o</option>
         <option value="gpt-4">GPT-4</option>
-        <option value="llama3">Llama 3</option>
+        <option value="qwen3:30b-a3b">Qwen3 30B A3b</option>
       </select>
     </label>
     <button id="save-settings">Save</button>

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ This repository contains the source for my personal site as well as **InsightMat
 2. Open the `InsightMate` folder in a terminal.
 3. For the full desktop app run `setup.bat`. This sets up a Python environment, installs Node dependencies and launches the Electron UI.
 4. If you only want the lightweight Tkinter GUI, open `InsightMate/Scripts` and run `windows_setup.ps1` to create the virtual environment and start the backend server, or run `python windows_gui.py` to open the chat window directly. If the window closes immediately it usually means a required package is missing – run `pip install -r requirements.txt` (or `windows_setup.ps1`) from a terminal so you can see any error messages. If `pip` fails with a `textract` error, downgrade to `pip` 23 (`python -m pip install pip==23.3`) or install `textract==1.6.3` manually.
-5. Copy `.env.example` to `.env` and set `OPENAI_API_KEY` if you want to use GPT-4o or GPT-4. You can also leave it blank and configure the key later from the **Settings** window. Without a key, InsightMate talks to the local Llama 3 model via [Ollama](https://ollama.ai/).
+5. Copy `.env.example` to `.env` and set `OPENAI_API_KEY` if you want to use GPT-4o or GPT-4. You can also leave it blank and configure the key later from the **Settings** window. Without a key, InsightMate talks to the local Qwen3 model via [Ollama](https://ollama.ai/).
 6. Place your Google API `credentials.json` in `InsightMate/Scripts` and run `python gmail_reader.py` once to authorize Gmail and Calendar access. This creates `token.json` for future runs.
-7. Ensure [`ollama`](https://ollama.ai/) is installed. `windows_setup.ps1` automatically downloads the Llama 3 model with `ollama pull llama3`. A 4090 GPU is used automatically when present.
+7. Ensure [`ollama`](https://ollama.ai/) is installed. `windows_setup.ps1` automatically downloads the Qwen3 model with `ollama pull qwen3:30b-a3b`. A 4090 GPU is used automatically when present.
 8. Minimizing the chat window hides it to the system tray so it can run in the background. Use the tray icon to restore or quit InsightMate.
-9. Open the **Settings** window (via the tray menu or the new button at the top of the chat window) to update your API key, choose between GPT-4o, GPT-4, **o4-mini**, **o4-mini-high** or Llama 3, and toggle between light and dark themes. Your last selections are remembered for the next run.
+9. Open the **Settings** window (via the tray menu or the new button at the top of the chat window) to update your API key, choose between GPT-4o, GPT-4, **o4-mini**, **o4-mini-high** or Qwen3, and toggle between light and dark themes. Your last selections are remembered for the next run.
 10. Use the **Voice** button to dictate a query if `speech_recognition` and `pyaudio` are installed.
 11. If the chat window shows connection errors, check `InsightMate/Scripts/chat_server.log` for details.
 12. Conversation history, unread email summaries and calendar events are stored locally in `InsightMate/Scripts/memory.db`. Settings are written to `InsightMate/Scripts/config.json`.
-13. The last few messages are sent to GPT‑4o, GPT‑4 or Llama 3 so chats keep their context across runs.
+13. The last few messages are sent to GPT‑4o, GPT‑4 or Qwen3 so chats keep their context across runs.
 14. To launch the Electron interface manually after the chat server is running, change to `InsightMate/electron` and run `npm start`. `setup.bat` performs this automatically when you run it.
 15. The Electron UI now shows **Reminders**, **Tasks** and a **Memory** panel so you can review scheduled jobs and recent conversations.
 


### PR DESCRIPTION
## Summary
- use `qwen3:30b-a3b` as the default model
- update the Ollama download script
- mention Qwen3 in the docs and UI dropdowns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6870850d0b348333beb4ce890ab6e17d