### PR TITLE
Add editable system prompt

### DIFF
--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -3,7 +3,7 @@ import subprocess
 from typing import Optional
 import openai
 from dotenv import load_dotenv
-from config import load_config, get_api_key, get_llm
+from config import load_config, get_api_key, get_llm, get_prompt
 
 from onedrive_reader import search, list_word_docs
 from gmail_reader import fetch_unread_email
@@ -48,8 +48,10 @@ def gpt(prompt: str) -> str:
     cfg = _get_config()
     llm = get_llm(cfg).lower()
     api_key = get_api_key(cfg)
+    system_prompt = get_prompt(cfg)
     history = get_recent_messages(10)
-    messages = [{"role": m[1], "content": m[2]} for m in history]
+    messages = [{"role": "system", "content": system_prompt}]
+    messages += [{"role": m[1], "content": m[2]} for m in history]
     messages.append({"role": "user", "content": prompt})
     if llm in {"gpt-4", "gpt-4o", "o4-mini", "o4-mini-high"}:
         if not api_key:

--- a/InsightMate/Scripts/config.py
+++ b/InsightMate/Scripts/config.py
@@ -5,7 +5,30 @@ CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config.json')
 DEFAULT_CONFIG = {
     'api_key': '',
     'llm': 'qwen3:30b-a3b',
-    'theme': 'dark'
+    'theme': 'dark',
+    'prompt': (
+        "You are InsightMate, a highly intelligent, concise, "
+        "and privacy-respecting local AI assistant.\n\n"
+        "Your goals:\n"
+        "- Provide accurate, helpful answers with a calm, natural tone.\n"
+        "- Keep responses short and to the point by default \u2014 only expand "
+        "if the user explicitly asks you to \"explain more\", "
+        "\"go into detail\", or \"give a long answer.\"\n"
+        "- Use markdown formatting (like **bold**, `code`, and bullet points) "
+        "when useful for clarity.\n"
+        "- Summarize long or technical content clearly unless told to quote "
+        "or include everything.\n"
+        "- Reference earlier context in the conversation when relevant, but "
+        "do not hallucinate memory beyond this session.\n\n"
+        "Your skills:\n"
+        "- Assist with scheduling, emails, local files, summarization, "
+        "technical topics, and reasoning.\n"
+        "- Answer like a thoughtful human expert: confident but never "
+        "arrogant.\n"
+        "- If unsure, say so. Never make up facts.\n\n"
+        "Do not explain how you work unless asked. Avoid excessive "
+        "verbosity. Always prioritize clarity and relevance."
+    ),
 }
 
 def load_config() -> dict:
@@ -40,3 +63,9 @@ def get_theme(cfg: dict | None = None) -> str:
     if cfg is None:
         cfg = load_config()
     return cfg.get('theme', DEFAULT_CONFIG['theme'])
+
+
+def get_prompt(cfg: dict | None = None) -> str:
+    if cfg is None:
+        cfg = load_config()
+    return cfg.get('prompt', DEFAULT_CONFIG['prompt'])

--- a/InsightMate/Scripts/windows_gui.py
+++ b/InsightMate/Scripts/windows_gui.py
@@ -205,15 +205,22 @@ class ChatGUI:
         theme_box = ttk.Combobox(win, textvariable=theme_var, values=['dark', 'light'], state='readonly')
         theme_box.grid(row=2, column=1, padx=5, pady=5)
 
+        prompt_val = self.config.get('prompt', '')
+        tk.Label(win, text='System Prompt:').grid(row=3, column=0, sticky='nw')
+        prompt_entry = ScrolledText(win, width=40, height=10)
+        prompt_entry.insert('1.0', prompt_val)
+        prompt_entry.grid(row=3, column=1, padx=5, pady=5)
+
         def save():
             self.config['api_key'] = api_var.get().strip()
             self.config['llm'] = llm_var.get()
             self.config['theme'] = theme_var.get()
+            self.config['prompt'] = prompt_entry.get('1.0', tk.END).strip()
             save_config(self.config)
             self.apply_theme()
             win.destroy()
 
-        tk.Button(win, text='Save', command=save).grid(row=3, column=0, columnspan=2, pady=10)
+        tk.Button(win, text='Save', command=save).grid(row=4, column=0, columnspan=2, pady=10)
 
     def quit_app(self, icon=None, item=None):
         self.on_close()


### PR DESCRIPTION
## Summary
- allow customizing a system prompt via `config.json`
- expose the prompt in the Windows GUI settings
- include the system prompt when chatting

## Testing
- `python -m py_compile InsightMate/Scripts/config.py InsightMate/Scripts/assistant_router.py InsightMate/Scripts/windows_gui.py`
- `find InsightMate -name '*.py' -print | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6870867ebed883338197ec01fc35c401