### PR TITLE
Fix google auth path handling

### DIFF
--- a/InsightMate/InsightMateApp/Resources/py/google_auth.py
+++ b/InsightMate/InsightMateApp/Resources/py/google_auth.py
@@ -8,20 +8,22 @@ SCOPES = [
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/calendar.readonly',
 ]
-TOKEN_FILE = 'token.json'
-CREDENTIALS_FILE = 'credentials.json'
+TOKEN_FILE = os.path.join(os.path.dirname(__file__), "token.json")
+CREDENTIALS_FILE = "credentials.json"
 
 def get_credentials():
     """Return authorized Google credentials for Gmail and Calendar."""
     creds = None
-    if os.path.exists(TOKEN_FILE):
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    token_path = TOKEN_FILE
+    credentials_path = os.path.join(os.path.dirname(__file__), CREDENTIALS_FILE)
+    if os.path.exists(token_path):
+        creds = Credentials.from_authorized_user_file(token_path, SCOPES)
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            flow = InstalledAppFlow.from_client_secrets_file(credentials_path, SCOPES)
             creds = flow.run_local_server(port=0)
-        with open(TOKEN_FILE, 'w') as token:
+        with open(token_path, 'w') as token:
             token.write(creds.to_json())
     return creds

--- a/InsightMate/Scripts/google_auth.py
+++ b/InsightMate/Scripts/google_auth.py
@@ -8,20 +8,22 @@ SCOPES = [
     'https://www.googleapis.com/auth/gmail.readonly',
     'https://www.googleapis.com/auth/calendar.readonly',
 ]
-TOKEN_FILE = 'token.json'
-CREDENTIALS_FILE = 'credentials.json'
+TOKEN_FILE = os.path.join(os.path.dirname(__file__), "token.json")
+CREDENTIALS_FILE = "credentials.json"
 
 def get_credentials():
     """Return authorized Google credentials for Gmail and Calendar."""
     creds = None
-    if os.path.exists(TOKEN_FILE):
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    token_path = TOKEN_FILE
+    credentials_path = os.path.join(os.path.dirname(__file__), CREDENTIALS_FILE)
+    if os.path.exists(token_path):
+        creds = Credentials.from_authorized_user_file(token_path, SCOPES)
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+            flow = InstalledAppFlow.from_client_secrets_file(credentials_path, SCOPES)
             creds = flow.run_local_server(port=0)
-        with open(TOKEN_FILE, 'w') as token:
+        with open(token_path, 'w') as token:
             token.write(creds.to_json())
     return creds


### PR DESCRIPTION
## Summary
- resolve token/credentials file path relative to module
- ensure Google auth works from any working directory

## Testing
- `python -m py_compile InsightMate/Scripts/google_auth.py InsightMate/InsightMateApp/Resources/py/google_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68708bc118c483338dc081ce15fde7b5