### PR TITLE
Fix timezone handling for Calendar API

### DIFF
--- a/InsightMate/InsightMateApp/Resources/py/calendar_reader.py
+++ b/InsightMate/InsightMateApp/Resources/py/calendar_reader.py
@@ -7,12 +7,13 @@ from google_auth import get_credentials
 def list_today_events():
     creds = get_credentials()
     service = build('calendar', 'v3', credentials=creds)
-    start = datetime.datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    tz = datetime.datetime.now().astimezone().tzinfo
+    start = datetime.datetime.now(tz).replace(hour=0, minute=0, second=0, microsecond=0)
     end = start + datetime.timedelta(days=1)
     events_result = service.events().list(
         calendarId='primary',
-        timeMin=start.isoformat() + 'Z',
-        timeMax=end.isoformat() + 'Z',
+        timeMin=start.isoformat(),
+        timeMax=end.isoformat(),
         singleEvents=True,
         orderBy='startTime'
     ).execute()

--- a/InsightMate/Scripts/calendar_reader.py
+++ b/InsightMate/Scripts/calendar_reader.py
@@ -7,12 +7,13 @@ from google_auth import get_credentials
 def list_today_events():
     creds = get_credentials()
     service = build('calendar', 'v3', credentials=creds)
-    start = datetime.datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    tz = datetime.datetime.now().astimezone().tzinfo
+    start = datetime.datetime.now(tz).replace(hour=0, minute=0, second=0, microsecond=0)
     end = start + datetime.timedelta(days=1)
     events_result = service.events().list(
         calendarId='primary',
-        timeMin=start.isoformat() + 'Z',
-        timeMax=end.isoformat() + 'Z',
+        timeMin=start.isoformat(),
+        timeMax=end.isoformat(),
         singleEvents=True,
         orderBy='startTime'
     ).execute()
@@ -29,12 +30,13 @@ def search_events(query: str, days: int = 30, limit: int = 10):
     """Search upcoming calendar events for the given text."""
     creds = get_credentials()
     service = build('calendar', 'v3', credentials=creds)
-    start = datetime.datetime.utcnow()
+    tz = datetime.datetime.now().astimezone().tzinfo
+    start = datetime.datetime.now(tz)
     end = start + datetime.timedelta(days=days)
     events_result = service.events().list(
         calendarId='primary',
-        timeMin=start.isoformat() + 'Z',
-        timeMax=end.isoformat() + 'Z',
+        timeMin=start.isoformat(),
+        timeMax=end.isoformat(),
         singleEvents=True,
         orderBy='startTime',
         q=query,


### PR DESCRIPTION
## Summary
- use the user's local timezone in `calendar_reader.py`
- ensure midnight start and local ISO format for daily event listing
- update `search_events()` to respect local timezone

## Testing
- `python -m py_compile InsightMate/Scripts/calendar_reader.py InsightMate/InsightMateApp/Resources/py/calendar_reader.py`

------
https://chatgpt.com/codex/tasks/task_e_68708bc299148333ae92650e7ac3ddbb