### PR TITLE
Fix calendar_reader events bug

### DIFF
--- a/InsightMate/Scripts/calendar_reader.py
+++ b/InsightMate/Scripts/calendar_reader.py
@@ -8,6 +8,25 @@ def list_events_for_day(offset_days: int) -> list[dict]:
     """Return calendar events for today plus ``offset_days`` days."""
     creds = get_credentials()
     service = build('calendar', 'v3', credentials=creds)
+    tz = datetime.datetime.now().astimezone().tzinfo
+    start = (
+        datetime.datetime.now(tz)
+        .replace(hour=0, minute=0, second=0, microsecond=0)
+        + datetime.timedelta(days=offset_days)
+    )
+    end = start + datetime.timedelta(days=1)
+    events_result = (
+        service.events()
+        .list(
+            calendarId="primary",
+            timeMin=start.isoformat(),
+            timeMax=end.isoformat(),
+            singleEvents=True,
+            orderBy="startTime",
+        )
+        .execute()
+    )
+    events = events_result.get("items", [])
     output = []
     for e in events:
         start_time = e["start"].get("dateTime", e["start"].get("date"))


### PR DESCRIPTION
## Summary
- fix undefined variable in `list_events_for_day`

## Testing
- `python -m py_compile InsightMate/Scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68708e6350ac8333a9001587bafe9010