### PR TITLE
Add calendar event creation

### DIFF
--- a/InsightMate/InsightMateApp/Resources/py/google_auth.py
+++ b/InsightMate/InsightMateApp/Resources/py/google_auth.py
@@ -6,7 +6,8 @@ from google.auth.transport.requests import Request
 
 SCOPES = [
     'https://www.googleapis.com/auth/gmail.readonly',
-    'https://www.googleapis.com/auth/calendar.readonly',
+    # Allow calendar events to be created
+    'https://www.googleapis.com/auth/calendar',
 ]
 TOKEN_FILE = os.path.join(os.path.dirname(__file__), "token.json")
 CREDENTIALS_FILE = "credentials.json"

--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -8,7 +8,12 @@ from config import load_config, get_api_key, get_llm, get_prompt
 
 from onedrive_reader import search, list_word_docs
 from gmail_reader import fetch_unread_email, search_emails
-from calendar_reader import list_today_events, list_events_for_day, search_events
+from calendar_reader import (
+    list_today_events,
+    list_events_for_day,
+    search_events,
+    create_event,
+)
 from dateparser import parse as parse_date
 from reminder_scheduler import (
     schedule as schedule_reminder,
@@ -121,6 +126,8 @@ def route(query: str) -> str:
             else:
                 lines = [f"{e['start']} {e['title']}" for e in events]
                 reply = '\n'.join(lines)
+    elif q.startswith('add event') or q.startswith('create event') or q.startswith('new event'):
+        reply = create_event(query)
     elif any(k in q for k in EMAIL_KEYWORDS):
         email = fetch_unread_email()
         save_email(email)

--- a/InsightMate/Scripts/calendar_reader.py
+++ b/InsightMate/Scripts/calendar_reader.py
@@ -2,6 +2,7 @@ import datetime
 from googleapiclient.discovery import build
 
 from google_auth import get_credentials
+from dateparser.search import search_dates
 
 
 def list_events_for_day(offset_days: int) -> list[dict]:
@@ -63,6 +64,42 @@ def search_events(query: str, days: int = 30, limit: int = 10):
         end_time = e['end'].get('dateTime', e['end'].get('date'))
         output.append({'title': e.get('summary', ''), 'start': start_time, 'end': end_time})
     return output
+
+
+def create_event(text: str) -> str:
+    """Create a calendar event from ``text``.
+
+    The first recognizable date in ``text`` is used as the start time and the
+    remainder becomes the title. A one hour duration is assumed.
+    """
+    matches = search_dates(text, settings={'PREFER_DATES_FROM': 'future'})
+    if not matches:
+        return 'Could not parse time.'
+
+    phrase, when = matches[0]
+    tz = datetime.datetime.now().astimezone().tzinfo
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=tz)
+    start = when
+    end = start + datetime.timedelta(hours=1)
+
+    title = text.replace(phrase, '').strip()
+    for p in ('add event', 'create event', 'new event', 'schedule event'):
+        if title.lower().startswith(p):
+            title = title[len(p):].strip()
+            break
+    if not title:
+        title = 'New Event'
+
+    creds = get_credentials()
+    service = build('calendar', 'v3', credentials=creds)
+    body = {
+        'summary': title,
+        'start': {'dateTime': start.isoformat()},
+        'end': {'dateTime': end.isoformat()},
+    }
+    service.events().insert(calendarId='primary', body=body).execute()
+    return f"Event '{title}' added for {start.isoformat()}"
 
 
 if __name__ == '__main__':

--- a/InsightMate/Scripts/google_auth.py
+++ b/InsightMate/Scripts/google_auth.py
@@ -6,7 +6,8 @@ from google.auth.transport.requests import Request
 
 SCOPES = [
     'https://www.googleapis.com/auth/gmail.readonly',
-    'https://www.googleapis.com/auth/calendar.readonly',
+    # Allow reading and writing calendar events
+    'https://www.googleapis.com/auth/calendar',
 ]
 TOKEN_FILE = os.path.join(os.path.dirname(__file__), "token.json")
 CREDENTIALS_FILE = "credentials.json"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the source for my personal site as well as **InsightMat
 3. For the full desktop app run `setup.bat`. This sets up a Python environment, installs Node dependencies and launches the Electron UI.
 4. If you only want the lightweight Tkinter GUI, open `InsightMate/Scripts` and run `windows_setup.ps1` to create the virtual environment and start the backend server, or run `python windows_gui.py` to open the chat window directly. If the window closes immediately it usually means a required package is missing – run `pip install -r requirements.txt` (or `windows_setup.ps1`) from a terminal so you can see any error messages. If `pip` fails with a `textract` error, downgrade to `pip` 23 (`python -m pip install pip==23.3`) or install `textract==1.6.3` manually.
 5. Copy `.env.example` to `.env` and set `OPENAI_API_KEY` if you want to use GPT-4o or GPT-4. You can also leave it blank and configure the key later from the **Settings** window. Without a key, InsightMate talks to the local Qwen3 model via [Ollama](https://ollama.ai/).
-6. Place your Google API `credentials.json` in `InsightMate/Scripts` and run `python gmail_reader.py` once to authorize Gmail and Calendar access. This creates `token.json` for future runs.
+6. Place your Google API `credentials.json` in `InsightMate/Scripts` and run `python gmail_reader.py` once to authorize Gmail and Calendar access. This creates `token.json` for future runs. If you previously granted read‑only calendar permissions, delete `token.json` and re‑run the script to allow event creation.
 7. Ensure [`ollama`](https://ollama.ai/) is installed. `windows_setup.ps1` automatically downloads the Qwen3 model with `ollama pull qwen3:30b-a3b`. A 4090 GPU is used automatically when present.
 8. Minimizing the chat window hides it to the system tray so it can run in the background. Use the tray icon to restore or quit InsightMate.
 9. Open the **Settings** window (via the tray menu or the new button at the top of the chat window) to update your API key, choose between GPT-4o, GPT-4, **o4-mini**, **o4-mini-high** or Qwen3, and toggle between light and dark themes. Your last selections are remembered for the next run.
@@ -20,6 +20,7 @@ This repository contains the source for my personal site as well as **InsightMat
 14. To launch the Electron interface manually after the chat server is running, change to `InsightMate/electron` and run `npm start`. `setup.bat` performs this automatically when you run it.
 15. The Electron UI now shows **Reminders**, **Tasks** and a **Memory** panel so you can review scheduled jobs and recent conversations.
 16. Ask InsightMate to `search email <keywords>` or `search calendar <keywords>` to query your Gmail inbox or upcoming events. Matching results are saved to the local memory database.
+17. Use `add event <title> <time>` to create a new calendar entry.
 
 See [InsightMate/README.md](InsightMate/README.md) for more details.
 


### PR DESCRIPTION
## Summary
- allow InsightMate to write to Google Calendar by requesting read/write scope
- implement `create_event` helper in `calendar_reader`
- handle `add event` commands in `assistant_router`
- mention new feature in the README and update setup instructions

## Testing
- `python -m py_compile InsightMate/Scripts/calendar_reader.py InsightMate/Scripts/assistant_router.py InsightMate/Scripts/google_auth.py`
- `python -m py_compile InsightMate/InsightMateApp/Resources/py/google_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68708f4947fc8333a719f69a6649c0e9