### PR TITLE
Use Pacific time zone for calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This repository contains the source for my personal site as well as **InsightMat
 17. Use `add event <title> <time>` to create a new calendar entry.
 18. Use `send email <address> <subject> <message>` to compose and send a Gmail message.
 
+Calendar events are scheduled in **Pacific Time** regardless of the host system's
+timezone.
+
 See [InsightMate/README.md](InsightMate/README.md) for more details.
 
 ## MCP Integration


### PR DESCRIPTION
## Summary
- pin all calendar operations to Pacific time
- document that events use Pacific time by default

## Testing
- `python3 -m py_compile InsightMate/Scripts/calendar_reader.py`

------
https://chatgpt.com/codex/tasks/task_e_687095a75b888333bf8a33044fed7d72