### PR TITLE
Add web interface instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,17 @@ timezone.
 
 See [InsightMate/README.md](InsightMate/README.md) for more details.
 
+## Web interface
+
+To start the chat server directly, run:
+
+```bash
+python Scripts/chat_server.py
+```
+
+Then open `http://<host>:5000/` in your browser (replace `<host>` with your
+computer's address). The server listens on all network interfaces so it can be
+reached from other devices on the same network.
+
 ## MCP Integration
 InsightMate leverages the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) platform to centralize configuration and neatly integrate all components.


### PR DESCRIPTION
## Summary
- document how to run the Flask chat server and reach it via browser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68709ab975148333a60baa367c37c282