### PR TITLE
Update Flask server configs

### DIFF
--- a/InsightMate/Scripts/ai_server.py
+++ b/InsightMate/Scripts/ai_server.py
@@ -4,7 +4,9 @@ import openai
 from dotenv import load_dotenv
 from assistant_router import route
 
-app = Flask(__name__)
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+STATIC_DIR = os.path.join(BASE_DIR, '../web')
+app = Flask(__name__, static_folder=STATIC_DIR, static_url_path='')
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -46,5 +48,10 @@ def chat():
     reply = route(query)
     return jsonify({'reply': reply})
 
+
+@app.route('/')
+def index():
+    return app.send_static_file('index.html')
+
 if __name__ == '__main__':
-    app.run(port=5000)
+    app.run(host='0.0.0.0', port=5000)

--- a/InsightMate/Scripts/chat_server.py
+++ b/InsightMate/Scripts/chat_server.py
@@ -5,7 +5,9 @@ from assistant_router import route
 from reminder_scheduler import list_reminders, list_tasks
 from memory_db import get_recent_messages
 
-app = Flask(__name__)
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+STATIC_DIR = os.path.join(BASE_DIR, '../web')
+app = Flask(__name__, static_folder=STATIC_DIR, static_url_path='')
 
 load_dotenv()
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
@@ -41,5 +43,10 @@ def memory():
     ]
     return jsonify({'messages': data})
 
+
+@app.route('/')
+def index():
+    return app.send_static_file('index.html')
+
 if __name__ == '__main__':
-    app.run(port=5000)
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- set `static_folder` and `static_url_path` on Flask servers
- add `/` route serving `index.html`
- listen on `0.0.0.0` for remote access

## Testing
- `python -m py_compile InsightMate/Scripts/chat_server.py InsightMate/Scripts/ai_server.py`
- *(failure)* `python InsightMate/Scripts/chat_server.py` *(missing googleapiclient)*

------
https://chatgpt.com/codex/tasks/task_e_68709ab6e29883338bedeca83ea15193