### PR TITLE
Refactor server entry points

### DIFF
--- a/InsightMate/InsightMateApp/Resources/py/ai_server.py
+++ b/InsightMate/InsightMateApp/Resources/py/ai_server.py
@@ -2,12 +2,15 @@ import os
 from flask import Flask, request, jsonify
 import openai
 from dotenv import load_dotenv
-from assistant_router import route_query
 
-app = Flask(__name__)
+from server_common import register_common, WEB_DIR
+
+app = Flask(__name__, static_folder=WEB_DIR, static_url_path='')
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
+
+register_common(app)
 
 
 def chat_completion(model: str, messages: list[dict]) -> str:
@@ -39,15 +42,6 @@ def process():
     return jsonify({'reply': reply})
 
 
-@app.route('/chat', methods=['POST'])
-def chat():
-    data = request.get_json() or {}
-    query = data.get('query', '')
-    routed = route_query(query)
-    if routed is not None:
-        return jsonify({'reply': routed})
-    reply = chat_completion("gpt-4", [{"role": "user", "content": query}])
-    return jsonify({'reply': reply})
-
 if __name__ == '__main__':
     app.run(port=5000)
+

--- a/InsightMate/Scripts/ai_server.py
+++ b/InsightMate/Scripts/ai_server.py
@@ -2,12 +2,15 @@ import os
 from flask import Flask, request, jsonify
 import openai
 from dotenv import load_dotenv
-from assistant_router import route
 
-app = Flask(__name__)
+from server_common import register_common, WEB_DIR
+
+app = Flask(__name__, static_folder=WEB_DIR, static_url_path='')
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
+
+register_common(app)
 
 
 def chat_completion(model: str, messages: list[dict]) -> str:
@@ -39,12 +42,6 @@ def process():
     return jsonify({'reply': reply})
 
 
-@app.route('/chat', methods=['POST'])
-def chat():
-    data = request.get_json() or {}
-    query = data.get('query', '')
-    reply = route(query)
-    return jsonify({'reply': reply})
-
 if __name__ == '__main__':
     app.run(port=5000)
+

--- a/InsightMate/Scripts/chat_server.py
+++ b/InsightMate/Scripts/chat_server.py
@@ -1,45 +1,15 @@
 import os
-from flask import Flask, request, jsonify
+from flask import Flask
 from dotenv import load_dotenv
-from assistant_router import route
-from reminder_scheduler import list_reminders, list_tasks
-from memory_db import get_recent_messages
 
-app = Flask(__name__)
+from server_common import register_common, WEB_DIR
+
+app = Flask(__name__, static_folder=WEB_DIR, static_url_path='')
 
 load_dotenv()
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
-@app.route('/chat', methods=['POST'])
-def chat():
-    data = request.get_json() or {}
-    message = data.get('message') or data.get('query') or ''
-    reply = route(message)
-    return jsonify({'reply': reply})
-
-
-@app.route('/reminders', methods=['GET'])
-def reminders():
-    rems = list_reminders()
-    data = [{'id': r[0], 'text': r[1], 'time': r[2]} for r in rems]
-    return jsonify({'reminders': data})
-
-
-@app.route('/tasks', methods=['GET'])
-def tasks():
-    tasks = list_tasks()
-    data = [{'id': t[0], 'type': t[1], 'description': t[2], 'schedule': t[3]} for t in tasks]
-    return jsonify({'tasks': data})
-
-
-@app.route('/memory', methods=['GET'])
-def memory():
-    messages = get_recent_messages()
-    data = [
-        {'ts': m[0], 'sender': m[1], 'text': m[2]}
-        for m in messages
-    ]
-    return jsonify({'messages': data})
+register_common(app)
 
 if __name__ == '__main__':
     app.run(port=5000)

--- a/InsightMate/Scripts/server_common.py
+++ b/InsightMate/Scripts/server_common.py
@@ -1,0 +1,45 @@
+import os
+from flask import Blueprint, jsonify, request, current_app
+
+from assistant_router import route
+from reminder_scheduler import list_reminders, list_tasks
+from memory_db import get_recent_messages
+
+WEB_DIR = os.path.join(os.path.dirname(__file__), '..', 'web')
+
+common_bp = Blueprint('common', __name__)
+
+@common_bp.route('/')
+def index():
+    """Serve the web interface."""
+    return current_app.send_static_file('index.html')
+
+@common_bp.route('/chat', methods=['POST'])
+def chat_route():
+    data = request.get_json() or {}
+    message = data.get('message') or data.get('query') or ''
+    reply = route(message)
+    return jsonify({'reply': reply})
+
+@common_bp.route('/reminders', methods=['GET'])
+def reminders_route():
+    rems = list_reminders()
+    data = [{'id': r[0], 'text': r[1], 'time': r[2]} for r in rems]
+    return jsonify({'reminders': data})
+
+@common_bp.route('/tasks', methods=['GET'])
+def tasks_route():
+    tasks = list_tasks()
+    data = [{'id': t[0], 'type': t[1], 'description': t[2], 'schedule': t[3]} for t in tasks]
+    return jsonify({'tasks': data})
+
+@common_bp.route('/memory', methods=['GET'])
+def memory_route():
+    messages = get_recent_messages()
+    data = [{'ts': m[0], 'sender': m[1], 'text': m[2]} for m in messages]
+    return jsonify({'messages': data})
+
+def register_common(app):
+    """Register common routes and static file handling on the given app."""
+    app.register_blueprint(common_bp)
+


### PR DESCRIPTION
## Summary
- share Flask routes via `server_common`
- use the shared module from `chat_server.py` and `ai_server.py`
- expose web UI from both entry points

## Testing
- `python -m py_compile InsightMate/Scripts/server_common.py InsightMate/Scripts/chat_server.py InsightMate/Scripts/ai_server.py InsightMate/InsightMateApp/Resources/py/ai_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68709ac3ee4c8333a0be0c3506bfcd20