### PR TITLE
Fix server launch scripts

### DIFF
--- a/InsightMate/Scripts/ai_server.py
+++ b/InsightMate/Scripts/ai_server.py
@@ -1,12 +1,18 @@
+"""Flask API server used by the Swift and Tkinter clients."""
+
 import os
+
 from flask import Flask, request, jsonify
 import openai
 from dotenv import load_dotenv
 
+from server_common import register_common, WEB_DIR
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
+# Expose the same static web interface used by the Electron build.
+app = Flask(__name__, static_folder=WEB_DIR, static_url_path="")
 register_common(app)
 
 
@@ -18,8 +24,10 @@ def chat_completion(model: str, messages: list[dict]) -> str:
     resp = openai.ChatCompletion.create(model=model, messages=messages)
     return resp["choices"][0]["message"]["content"].strip()
 
+
 @app.route('/process', methods=['POST'])
 def process():
+    """Process data from the macOS helper and return an assistant reply."""
     data = request.get_json() or {}
     imessage = data.get('imessage')
     email = data.get('email')
@@ -39,5 +47,5 @@ def process():
     return jsonify({'reply': reply})
 
 
-
-
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/InsightMate/Scripts/chat_server.py
+++ b/InsightMate/Scripts/chat_server.py
@@ -1,22 +1,24 @@
+"""Minimal Flask server for the InsightMate Electron app."""
+
 import os
+
 from flask import Flask
 from dotenv import load_dotenv
 
+from server_common import register_common, WEB_DIR
+
 
 load_dotenv()
-OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
+# Serve files from the shared web directory.  ``static_url_path`` is set to
+# ``''`` so URLs match ``/index.html`` rather than ``/static/index.html``.
+app = Flask(__name__, static_folder=WEB_DIR, static_url_path="")
+
+# Register routes such as ``/chat`` and ``/reminders`` defined in
+# ``server_common.py``.
 register_common(app)
 
 
-@app.route('/')
-def index():
-    return app.send_static_file('index.html')
-
-
-@app.route('/')
-def index():
-    return app.send_static_file('index.html')
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+if __name__ == "__main__":
+    # Listen on all interfaces so the Electron client can connect locally.
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- rebuild chat server script used by setup.bat
- rebuild ai server script used by other clients

## Testing
- `python -m py_compile InsightMate/Scripts/chat_server.py InsightMate/Scripts/ai_server.py`
- *Unable to run server due to missing flask module*

------
https://chatgpt.com/codex/tasks/task_e_68709e48d61c833386d12c5b7bc81c12