### PR TITLE
Update UI with toggle panels and streaming-like responses

### DIFF
--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -234,6 +234,9 @@ def route(query: str) -> str:
         else:
             lines = [f"{m[0]} {m[1]}: {m[2]}" for m in mem]
             reply = '\n'.join(lines)
+    elif 'current time' in q or q.startswith('what time') or q == 'time':
+        now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        reply = f'The current time is {now}'
     elif 'open' in q or 'launch' in q or 'play' in q:
         reply = execute_action(query)
     else:

--- a/InsightMate/electron/index.html
+++ b/InsightMate/electron/index.html
@@ -127,6 +127,7 @@
     background: #f0f0f0;
     color: #000;
   }
+  .d-none { display: none; }
   </style>
 </head>
 <body>
@@ -140,16 +141,16 @@
     <textarea id="input" rows="3" placeholder="Type a message..."></textarea>
   </div>
   <div id="reminders">
-    <h3>Reminders</h3>
-    <div id="reminder-list"></div>
+    <h3 id="reminder-toggle" style="cursor:pointer">Reminders</h3>
+    <div id="reminder-list" class="d-none"></div>
   </div>
   <div id="tasks">
-    <h3>Tasks</h3>
-    <div id="task-list"></div>
+    <h3 id="task-toggle" style="cursor:pointer">Tasks</h3>
+    <div id="task-list" class="d-none"></div>
   </div>
   <div id="memory">
-    <h3>Memory</h3>
-    <div id="memory-list"></div>
+    <h3 id="memory-toggle" style="cursor:pointer">Memory</h3>
+    <div id="memory-list" class="d-none"></div>
   </div>
 </div>
 <div id="settings-modal">

--- a/InsightMate/web/index.html
+++ b/InsightMate/web/index.html
@@ -31,16 +31,16 @@
       <button id="send-btn" class="btn btn-primary">Send</button>
     </div>
     <div class="col-12 col-md-2 mb-3">
-      <h5>Reminders</h5>
-      <div id="reminder-list" class="small"></div>
+      <h5 id="reminder-toggle" style="cursor:pointer">Reminders</h5>
+      <div id="reminder-list" class="small d-none"></div>
     </div>
     <div class="col-12 col-md-2 mb-3">
-      <h5>Tasks</h5>
-      <div id="task-list" class="small"></div>
+      <h5 id="task-toggle" style="cursor:pointer">Tasks</h5>
+      <div id="task-list" class="small d-none"></div>
     </div>
     <div class="col-12 col-md-2 mb-3">
-      <h5>Memory</h5>
-      <div id="memory-list" class="small"></div>
+      <h5 id="memory-toggle" style="cursor:pointer">Memory</h5>
+      <div id="memory-list" class="small d-none"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- respond to "current time" queries
- hide reminders, tasks and memory sections until clicked
- show placeholder while waiting for assistant responses and then animate text

## Testing
- `python -m py_compile InsightMate/Scripts/assistant_router.py`
- `python -m py_compile InsightMate/Scripts/*py`

------
https://chatgpt.com/codex/tasks/task_e_6870a00d7d28833387105dced8628602