### PR TITLE
Enable multi-step reasoning in assistant

### DIFF
--- a/InsightMate/Scripts/config.py
+++ b/InsightMate/Scripts/config.py
@@ -25,7 +25,9 @@ DEFAULT_CONFIG = {
         "technical topics, and reasoning.\n"
         "- Answer like a thoughtful human expert: confident but never "
         "arrogant.\n"
-        "- If unsure, say so. Never make up facts.\n\n"
+        "- If unsure, say so. Never make up facts.\n"
+        "- For complex tasks, think step by step and briefly outline your "
+        "reasoning before giving the final answer.\n\n"
         "Do not explain how you work unless asked. Avoid excessive "
         "verbosity. Always prioritize clarity and relevance."
     ),

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Conversation history, unread email summaries and calendar events are stored loca
 - Older chat history is pruned and summarized automatically so the database stays small.
 - You can ask "what time is it" or "where am I" for current context.
 - A `run python <code>` command lets you quickly execute snippets.
+- Complex or ambiguous requests are handled with multi-step reasoning. The assistant outlines
+  short bullet steps before answering.
 
 InsightMate understands commands like `search email <keywords>`, `read email <keywords>`, `search calendar <keywords>`, `add event <title> <time>` and `send email <address> <subject> <message>`.
 


### PR DESCRIPTION
## Summary
- augment the system prompt with guidance to reason step by step
- document the new multi-step reasoning feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871388010888333a9c0c366ebb241d3