### PR TITLE
Add reset memory button

### DIFF
--- a/InsightMate/Scripts/memory_db.py
+++ b/InsightMate/Scripts/memory_db.py
@@ -153,3 +153,11 @@ def list_tasks() -> List[Tuple[int, str, str, str]]:
     rows = c.fetchall()
     conn.close()
     return rows
+
+
+def clear_memory() -> None:
+    """Delete all chat messages from the local memory database."""
+    conn = _connect()
+    conn.execute('DELETE FROM messages')
+    conn.commit()
+    conn.close()

--- a/InsightMate/Scripts/server_common.py
+++ b/InsightMate/Scripts/server_common.py
@@ -3,7 +3,7 @@ from flask import Blueprint, jsonify, request, current_app
 
 from assistant_router import route
 from reminder_scheduler import list_reminders, list_tasks
-from memory_db import get_recent_messages
+from memory_db import get_recent_messages, clear_memory
 
 WEB_DIR = os.path.join(os.path.dirname(__file__), '..', 'web')
 
@@ -38,6 +38,12 @@ def memory_route():
     messages = get_recent_messages()
     data = [{'ts': m[0], 'sender': m[1], 'text': m[2]} for m in messages]
     return jsonify({'messages': data})
+
+
+@common_bp.route('/memory/reset', methods=['POST'])
+def memory_reset_route():
+    clear_memory()
+    return jsonify({'status': 'ok'})
 
 def register_common(app):
     """Register common routes and static file handling on the given app."""

--- a/InsightMate/web/app.js
+++ b/InsightMate/web/app.js
@@ -5,6 +5,7 @@ const memoryDiv = document.getElementById('memory-list');
 const reminderToggle = document.getElementById('reminder-toggle');
 const taskToggle = document.getElementById('task-toggle');
 const memoryToggle = document.getElementById('memory-toggle');
+const resetMemoryBtn = document.getElementById('reset-memory');
 const input = document.getElementById('input');
 const sendBtn = document.getElementById('send-btn');
 const settingsBtn = document.getElementById('settings-btn');
@@ -77,6 +78,11 @@ taskToggle.addEventListener('click', () => {
 });
 memoryToggle.addEventListener('click', () => {
   memoryDiv.classList.toggle('d-none');
+});
+resetMemoryBtn.addEventListener('click', () => {
+  fetch('/memory/reset', {method: 'POST'})
+    .then(fetchData)
+    .catch(() => {});
 });
 
 function loadSettings() {

--- a/InsightMate/web/index.html
+++ b/InsightMate/web/index.html
@@ -41,6 +41,7 @@
     <div class="col-12 col-md-2 mb-3">
       <h5 id="memory-toggle" style="cursor:pointer">Memory</h5>
       <div id="memory-list" class="small d-none"></div>
+      <button id="reset-memory" class="btn btn-sm btn-danger mt-2">Reset</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add ability to clear conversation history
- expose endpoint `/memory/reset`
- include Reset button in web interface
- hook button up in client JavaScript

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68713e4b77408333862ae70cbc3ecf35