### PR TITLE
Add multi-step reasoning

### DIFF
--- a/InsightMate/Scripts/assistant_router.py
+++ b/InsightMate/Scripts/assistant_router.py
@@ -136,6 +136,18 @@ def gpt(prompt: str) -> str:
     return out.decode().strip()
 
 
+def plan_then_answer(prompt: str) -> str:
+    """Generate a short bullet plan then answer using that plan."""
+    plan = gpt(
+        "Break down the following request into 2-4 short bullet steps. "
+        "Only return the bullet list.\n" + prompt
+    )
+    answer = gpt(
+        "Using the plan below, provide the final answer.\n\nPlan:\n" + plan + f"\n\nQuestion: {prompt}"
+    )
+    return plan + "\n\n" + answer
+
+
 def _extract_minutes(text: str) -> Optional[int]:
     import re
     match = re.search(r'(\d+)\s*(minute|hour)', text)
@@ -361,6 +373,6 @@ def route(query: str) -> str:
     elif 'open' in q or 'launch' in q or 'play' in q:
         reply = execute_action(query)
     else:
-        reply = gpt(query)
+        reply = plan_then_answer(query)
     save_message('assistant', reply)
     return reply

--- a/PRD.md
+++ b/PRD.md
@@ -8,6 +8,9 @@ InsightMate is a cross-platform personal assistant bundled within this repositor
 - Offer flexible language model choices (OpenAI API or local Llama 3 via Ollama).
 - Allow quick interaction through an always‑on UI with optional voice input and system tray control.
 - Maintain compatibility with the Model Context Protocol (MCP) standard to simplify future integrations.
+- Handle complex requests with multi-step thinking and processing so the assistant can plan before answering.
+  This is implemented via a new `plan_then_answer()` helper that first asks the model to outline
+  bullet steps before producing the final reply.
 
 ## Current Features
 - **Python backend** with Flask `chat_server.py` for routing assistant queries and scheduling reminders.
@@ -18,6 +21,7 @@ InsightMate is a cross-platform personal assistant bundled within this repositor
 - **Email and calendar search** so the assistant can `search email` or `search calendar` for specific information on demand.
 - **Sending email** via the `send email` command to compose and dispatch Gmail messages.
 - **Reading full emails** with `read email <keywords>` to retrieve the full message body.
+- **Multi-step reasoning** that outlines short bullet steps before performing complex actions using the `plan_then_answer()` helper.
 
 ## Use Cases
 1. Quickly query recent email or calendar events while chatting with GPT‑4o.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Conversation history, unread email summaries and calendar events are stored loca
 - Older chat history is pruned and summarized automatically so the database stays small.
 - You can ask "what time is it" or "where am I" for current context.
 - A `run python <code>` command lets you quickly execute snippets.
-- Complex or ambiguous requests are handled with multi-step reasoning. The assistant outlines
-  short bullet steps before answering.
+- Complex or ambiguous requests are handled with multi-step thinking and processing. The assistant now
+  generates a short bullet plan, follows that plan, then replies with both the plan and final answer.
 
 InsightMate understands commands like `search email <keywords>`, `read email <keywords>`, `search calendar <keywords>`, `add event <title> <time>` and `send email <address> <subject> <message>`.
 


### PR DESCRIPTION
## Summary
- implement `plan_then_answer()` to generate a short plan then reply
- use that helper for generic queries
- document the multi-step reasoning helper in README and PRD

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687140f6e6f083339dabe61d2fde7aa7