### PR TITLE
Fix plan_then_answer deep analysis

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -8,9 +8,9 @@ InsightMate is a cross-platform personal assistant bundled within this repositor
 - Offer flexible language model choices (OpenAI API or local Llama 3 via Ollama).
 - Allow quick interaction through an always‑on UI with optional voice input and system tray control.
 - Maintain compatibility with the Model Context Protocol (MCP) standard to simplify future integrations.
-- Handle complex requests with multi-step thinking and processing so the assistant can plan before answering.
-  This is implemented via a new `plan_then_answer()` helper that first asks the model to outline
-  bullet steps before producing the final reply.
+  - Handle complex requests with multi-step thinking and processing so the assistant can plan before answering.
+    This is implemented via a `plan_then_answer()` helper that first asks the model to outline
+    bullet steps, then runs a short analysis loop to refine the plan before producing the final reply.
 
 ## Current Features
 - **Python backend** with Flask `chat_server.py` for routing assistant queries and scheduling reminders.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Conversation history, unread email summaries and calendar events are stored loca
 - You can ask "what time is it" or "where am I" for current context.
 - A `run python <code>` command lets you quickly execute snippets.
 - Complex or ambiguous requests are handled with multi-step thinking and processing. The assistant now
-  generates a short bullet plan, follows that plan, then replies with both the plan and final answer.
+  generates a short bullet plan, runs a brief analysis loop to refine it, then replies with both the plan,
+  notes from that analysis and the final answer.
 
 InsightMate understands commands like `search email <keywords>`, `read email <keywords>`, `search calendar <keywords>`, `add event <title> <time>` and `send email <address> <subject> <message>`.
 


### PR DESCRIPTION
## Summary
- refine README instructions for multi-step reasoning
- refine product requirements description
- expand `plan_then_answer()` in `assistant_router.py` with a recurring analysis loop

## Testing
- `python -m py_compile InsightMate/Scripts/assistant_router.py`

------
https://chatgpt.com/codex/tasks/task_e_687173bf2e9c8333901332bec634c757