### PR TITLE
Add memory and reasoning features

### DIFF
--- a/InsightMate/Scripts/server_common.py
+++ b/InsightMate/Scripts/server_common.py
@@ -36,7 +36,7 @@ def tasks_route():
 @common_bp.route('/memory', methods=['GET'])
 def memory_route():
     messages = get_recent_messages()
-    data = [{'ts': m[0], 'sender': m[1], 'text': m[2]} for m in messages]
+    data = [{'user': m['user'], 'assistant': m['assistant']} for m in messages]
     return jsonify({'messages': data})
 
 

--- a/InsightMate/Scripts/summarizer.py
+++ b/InsightMate/Scripts/summarizer.py
@@ -1,0 +1,7 @@
+from assistant_router import gpt
+
+
+def summarize_text(text: str) -> str:
+    """Return a short summary of the provided text using the configured LLM."""
+    prompt = "Summarize the following text:\n\n" + text
+    return gpt(prompt)


### PR DESCRIPTION
## Summary
- implement paired message storage and retrieval
- add chain-of-thought options in planner
- allow natural language date handling
- enable multi-step tool chaining with summarization
- record history after replies

## Testing
- `python -m py_compile InsightMate/Scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68717f4a18bc833384f731099143f9f0