### PR TITLE
Initialize db

### DIFF
--- a/InsightMate/Scripts/chat_server.py
+++ b/InsightMate/Scripts/chat_server.py
@@ -6,9 +6,11 @@ from flask import Flask
 from dotenv import load_dotenv
 
 from server_common import register_common, WEB_DIR
+from memory_db import init_db
 
 
 load_dotenv()
+init_db()
 
 # Serve files from the shared web directory.  ``static_url_path`` is set to
 # ``''`` so URLs match ``/index.html`` rather than ``/static/index.html``.

--- a/InsightMate/Scripts/main.py
+++ b/InsightMate/Scripts/main.py
@@ -9,9 +9,11 @@ from imessage_reader import read_latest_imessage
 from onedrive_reader import list_recent_files
 from send_imessage import send_imessage
 from summarizer import summarize_text
-from memory_db import save_message, get_recent_messages
+from memory_db import init_db, save_message, get_recent_messages
 
 OUTPUT_FILE = '/tmp/insight_output.txt'
+
+init_db()
 
 def main(prompt: str = "Summarize recent activity."):
     print("Planning...")

--- a/InsightMate/Scripts/memory_db.py
+++ b/InsightMate/Scripts/memory_db.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 from typing import List, Tuple, Dict
 
-DB_PATH = os.path.join(os.path.dirname(__file__), 'memory.db')
+DB_PATH = os.path.join(os.path.dirname(__file__), "memory.db")
 
 
 def _connect():
@@ -10,15 +10,18 @@ def _connect():
 
 
 def init_db():
-    conn = _connect()
+    """Initialize the SQLite database if it doesn't already exist."""
+    conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute(
-        'CREATE TABLE IF NOT EXISTS messages ('
-        'id INTEGER PRIMARY KEY AUTOINCREMENT,'
-        'ts DATETIME DEFAULT CURRENT_TIMESTAMP,'
-        'user TEXT,'
-        'assistant TEXT'
-        ')'
+        """
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user TEXT NOT NULL,
+            assistant TEXT NOT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """
     )
     c.execute(
         'CREATE TABLE IF NOT EXISTS emails ('
@@ -57,9 +60,6 @@ def init_db():
     )
     conn.commit()
     conn.close()
-
-
-init_db()
 
 
 def save_message(user_input: str, ai_reply: str, limit: int = 100) -> None:

--- a/InsightMate/Scripts/server_common.py
+++ b/InsightMate/Scripts/server_common.py
@@ -16,10 +16,16 @@ def index():
 
 @common_bp.route('/chat', methods=['POST'])
 def chat_route():
-    data = request.get_json() or {}
-    message = data.get('message') or data.get('query') or ''
-    reply = route(message)
-    return jsonify({'reply': reply})
+    """Process a chat message and return the assistant's reply as JSON."""
+    try:
+        data = request.get_json() or {}
+        message = data.get('message') or data.get('query') or ''
+        reply = route(message)
+        return jsonify({'reply': reply})
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        return jsonify({'error': str(e)}), 500
 
 @common_bp.route('/reminders', methods=['GET'])
 def reminders_route():


### PR DESCRIPTION
## Summary
- create `init_db` function to ensure messages table exists
- call `init_db()` when starting `chat_server` or running `main`
- handle errors in `/chat` route so JSON is always returned

## Testing
- `python -m py_compile InsightMate/Scripts/memory_db.py InsightMate/Scripts/chat_server.py InsightMate/Scripts/server_common.py InsightMate/Scripts/main.py`
- `python InsightMate/Scripts/chat_server.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python InsightMate/Scripts/main.py "Hello"` *(fails: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68718279cf348333823b201fb99aac1b