### PR TITLE
Fix circular import for summarizer

### DIFF
--- a/InsightMate/Scripts/llm_client.py
+++ b/InsightMate/Scripts/llm_client.py
@@ -1,0 +1,39 @@
+import requests
+import openai
+
+
+def gpt(prompt: str, model: str = "qwen:30b-a3b") -> str:
+    return chat_completion(model, [{"role": "user", "content": prompt}])
+
+
+def chat_completion(model: str, messages: list[dict]) -> str:
+    if model.startswith("gpt-"):
+        return openai.ChatCompletion.create(
+            model=model,
+            messages=messages
+        )["choices"][0]["message"]["content"].strip()
+
+    response = requests.post(
+        "http://localhost:11434/api/chat",
+        json={"model": model, "messages": messages, "stream": True},
+        stream=True
+    )
+    response.raise_for_status()
+
+    full_reply = ""
+    for line in response.iter_lines():
+        if not line:
+            continue
+        if line.startswith(b'data: '):
+            line = line[6:]
+        try:
+            chunk = line.decode("utf-8").strip()
+            if chunk == "[DONE]":
+                break
+            content = requests.utils.json.loads(chunk).get("message", {}).get("content", "")
+            full_reply += content
+        except Exception as e:
+            full_reply += f"\n\u26a0\ufe0f Stream decode error: {e}"
+            break
+
+    return full_reply.strip()

--- a/InsightMate/Scripts/summarizer.py
+++ b/InsightMate/Scripts/summarizer.py
@@ -1,4 +1,4 @@
-from assistant_router import gpt
+from llm_client import gpt
 
 
 def summarize_text(text: str) -> str:


### PR DESCRIPTION
## Summary
- extract `gpt` and streaming helper into new `llm_client` module
- import `llm_client` in `assistant_router` and `summarizer`
- remove duplicate `chat_completion` from `assistant_router`

## Testing
- `python -m py_compile InsightMate/Scripts/llm_client.py InsightMate/Scripts/assistant_router.py InsightMate/Scripts/summarizer.py`

------
https://chatgpt.com/codex/tasks/task_e_6871913ec0448333ab3346b7359c95fe