### PR TITLE
Use UI-selected model everywhere

### DIFF
--- a/InsightMate/Scripts/llm_client.py
+++ b/InsightMate/Scripts/llm_client.py
@@ -2,7 +2,8 @@ import requests
 import openai
 
 
-def gpt(prompt: str, model: str = "qwen:30b-a3b") -> str:
+def gpt(prompt: str, model: str) -> str:
+    """Return a chat completion for ``prompt`` using ``model``."""
     return chat_completion(model, [{"role": "user", "content": prompt}])
 
 

--- a/InsightMate/Scripts/main.py
+++ b/InsightMate/Scripts/main.py
@@ -1,5 +1,4 @@
 import json
-import openai
 from dateparser import parse as parse_date
 
 from assistant_router import plan_actions
@@ -53,8 +52,9 @@ def main(prompt: str = "Summarize recent activity."):
     messages.append({"role": "user", "content": prompt})
 
     print('Contacting model...')
-    resp = openai.ChatCompletion.create(model="gpt-4", messages=messages)
-    reply = resp.choices[0].message.content.strip()
+    from llm_client import chat_completion
+    from user_settings import get_selected_model
+    reply = chat_completion(get_selected_model(), messages)
     print('AI reply:', reply)
     with open(OUTPUT_FILE, 'w') as f:
         f.write(reply)

--- a/InsightMate/Scripts/server_common.py
+++ b/InsightMate/Scripts/server_common.py
@@ -2,6 +2,7 @@ import os
 from flask import Blueprint, jsonify, request, current_app
 
 from assistant_router import route
+from user_settings import set_selected_model
 from reminder_scheduler import list_reminders, list_tasks
 from memory_db import get_recent_messages, clear_memory
 
@@ -20,6 +21,9 @@ def chat_route():
     try:
         data = request.get_json() or {}
         message = data.get('message') or data.get('query') or ''
+        model = data.get('model')
+        if model:
+            set_selected_model(model)
         reply = route(message)
         return jsonify({'reply': reply})
     except Exception as e:

--- a/InsightMate/Scripts/summarizer.py
+++ b/InsightMate/Scripts/summarizer.py
@@ -1,7 +1,8 @@
 from llm_client import gpt
+from user_settings import get_selected_model
 
 
 def summarize_text(text: str) -> str:
     """Return a short summary of the provided text using the configured LLM."""
     prompt = "Summarize the following text:\n\n" + text
-    return gpt(prompt)
+    return gpt(prompt, get_selected_model())

--- a/InsightMate/Scripts/user_settings.py
+++ b/InsightMate/Scripts/user_settings.py
@@ -1,0 +1,17 @@
+_selected_model = None
+
+from config import load_config, get_llm
+
+def set_selected_model(model: str) -> None:
+    """Store the currently selected LLM model."""
+    global _selected_model
+    if model:
+        _selected_model = model
+
+
+def get_selected_model() -> str:
+    """Return the selected LLM model, falling back to config."""
+    if _selected_model:
+        return _selected_model
+    cfg = load_config()
+    return get_llm(cfg)


### PR DESCRIPTION
## Summary
- centralize current LLM choice in `user_settings`
- accept model for completions in `llm_client.gpt`
- feed the chosen model to planner and small talk responses
- persist selected model from the chat API
- adjust summarizer and CLI script to use the dynamic model

## Testing
- `python -m py_compile InsightMate/Scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68719283e9188333a1eb398a7b4a392f