### PR TITLE
Fix PhotosPicker property and bundle ID

### DIFF
--- a/DepthOverlay/Info.plist
+++ b/DepthOverlay/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleDisplayName</key>
     <string>DepthOverlay</string>
     <key>CFBundleIdentifier</key>
-    <string>com.example.DepthOverlay</string>
+    <string>com.example.DepthOverlayApp</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleName</key>

--- a/DepthOverlay/Sources/ContentView.swift
+++ b/DepthOverlay/Sources/ContentView.swift
@@ -52,7 +52,7 @@ struct ContentView: View {
                let uiImage = UIImage(data: data) {
                 self.pickedImage = uiImage
             }
-            if let id = item.assetIdentifier {
+            if let id = item.itemIdentifier {
                 fetchDepth(assetID: id)
             }
         }


### PR DESCRIPTION
## Summary
- update SwiftUI image picker code to use `itemIdentifier`
- align app bundle ID in Info.plist with project settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688af2c500a88333a94f2d79eb76ade0